### PR TITLE
Feat!: Enhance pull request close/reconciliation handling

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -68,7 +68,7 @@ on:
       PRESERVE_GITHUB_PRS:
         description: "Do not close GitHub PRs after pushing to Gerrit"
         required: false
-        default: false
+        default: true
         type: boolean
       DRY_RUN:
         description: "Validate settings and PR metadata; do not write to Gerrit"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -40,6 +40,7 @@ jobs:
           GERRIT_KNOWN_HOSTS: 'dummy-host ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC...'
           GERRIT_SSH_PRIVKEY_G2G: 'dummy-key'
           DRY_RUN: 'true'
+          AUTOMATION_ONLY: 'false'
 
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [Failure]"
@@ -53,6 +54,7 @@ jobs:
           GERRIT_KNOWN_HOSTS: "dummy-host ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC..."
           GERRIT_SSH_PRIVKEY_G2G: ""
           DRY_RUN: 'true'
+          AUTOMATION_ONLY: 'false'
 
       # Failure testing is also important
       - name: "Error if step above did NOT fail"

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,11 @@ inputs:
   PRESERVE_GITHUB_PRS:
     description: "Do not close GitHub PRs after pushing to Gerrit"
     required: false
-    default: "false"
+    default: "true"
+  CLOSE_MERGED_PRS:
+    description: "Close GitHub PRs when corresponding Gerrit changes are merged"
+    required: false
+    default: "true"
   DRY_RUN:
     description: "Validate settings/PR metadata; do not write to Gerrit"
     required: false
@@ -65,10 +69,20 @@ inputs:
     description: "Enable CI testing mode; overrides .gitreview, creates orphan commits"
     required: false
     default: "false"
+  FORCE:
+    description: "Force PR closure regardless of Gerrit change status (abandoned, etc)"
+    required: false
+    default: "false"
   ISSUE_ID:
     description: "Issue ID to include (e.g., ABC-123)"
     required: false
     default: ""
+  USE_LOCAL_ACTION:
+    description: >-
+      Use local repository action/code instead of the PyPI package.
+      Set to 'true' when testing changes in a fork or branch before merging.
+    required: false
+    default: "false"
   G2G_USE_SSH_AGENT:
     description: "Use SSH agent for authentication instead of file-based keys (recommended)"
     required: false
@@ -115,6 +129,10 @@ inputs:
       (format: [{"key": "username", "value": "ISSUE-ID"}])
     required: false
     default: "[]"
+  AUTOMATION_ONLY:
+    description: "Only accept pull requests from known automation tools"
+    required: false
+    default: "true"
 
 outputs:
   gerrit_change_request_url:
@@ -157,7 +175,8 @@ runs:
         set -euo pipefail
         uv --version
         # Install locally for self-testing, use uvx for external repos
-        if [[ "${{ github.repository }}" =~ lfreleng-actions/github2gerrit-action ]]; then
+        if [[ "${{ inputs.USE_LOCAL_ACTION }}" == "true" ]] || \
+           [[ "${{ github.repository }}" =~ lfreleng-actions/github2gerrit-action ]]; then
           echo "Installing with: uv pip install --system ${{ github.action_path }}"
           uv pip install --system ${{ github.action_path }}
         else
@@ -199,6 +218,16 @@ runs:
       run: |
         # Extract PR number, validate context
         set -euo pipefail
+
+        # Push events don't need PR_NUMBER (used for closing merged PRs)
+        # The CLI handles push events specially via _process_close_merged_prs()
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          echo "Push event detected - will process merged commits for PR closure"
+          # Set PR_NUMBER to empty to indicate this is intentional for push events
+          echo "PR_NUMBER=" >> "$GITHUB_ENV"
+          exit 0
+        fi
+
         # Honor PR_NUMBER or SYNC_ALL_OPEN_PRS set by workflow_dispatch
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           if [[ -n "${SYNC_ALL_OPEN_PRS:-}" ]]; then
@@ -249,10 +278,13 @@ runs:
         ISSUE_ID: ${{ inputs.ISSUE_ID }}
         ISSUE_ID_LOOKUP_JSON: ${{ inputs.ISSUE_ID_LOOKUP_JSON }}
         CI_TESTING: ${{ inputs.CI_TESTING }}
+        CLOSE_MERGED_PRS: ${{ inputs.CLOSE_MERGED_PRS }}
+        FORCE: ${{ inputs.FORCE }}
         DUPLICATE_TYPES: ${{ inputs.DUPLICATE_TYPES }}
         NORMALISE_COMMIT: ${{ inputs.NORMALISE_COMMIT }}
         G2G_USE_SSH_AGENT: ${{ inputs.G2G_USE_SSH_AGENT }}
         G2G_VERBOSE: ${{ inputs.VERBOSE }}
+        AUTOMATION_ONLY: ${{ inputs.AUTOMATION_ONLY }}
 
         # Optional Gerrit overrides (when .gitreview is missing)
         GERRIT_SERVER: ${{ inputs.GERRIT_SERVER }}
@@ -280,8 +312,9 @@ runs:
       run: |
         # Run github2gerrit Python CLI
         set -euo pipefail
-        # Use different invocation methods based on repository
-        if [[ "${{ github.repository }}" =~ lfreleng-actions/github2gerrit-action ]]; then
+        # Use different invocation methods based on repository or USE_LOCAL_ACTION flag
+        if [[ "${{ inputs.USE_LOCAL_ACTION }}" == "true" ]] || \
+           [[ "${{ github.repository }}" =~ lfreleng-actions/github2gerrit-action ]]; then
           echo "Running:python -m github2gerrit.cli"
           python -m github2gerrit.cli
         else

--- a/docs/RELEASE-v0.2.0.md
+++ b/docs/RELEASE-v0.2.0.md
@@ -1,0 +1,561 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 The Linux Foundation -->
+
+# Release Notes - v0.2.0
+
+## Overview
+
+Version 0.2.0 introduces important behavioral changes and improvements to the
+GitHub2Gerrit action. This release focuses on making the default behavior more
+aligned with common use cases and improving the handling of push events.
+
+## Breaking Changes
+
+### ⚠️ PRESERVE_GITHUB_PRS Default Changed from `false` to `true`
+
+**Impact:** HIGH - This is a breaking change that affects default workflow behavior
+
+**Previous Behavior (v0.1.x):**
+
+- Default: `PRESERVE_GITHUB_PRS="false"`
+- GitHub pull requests closed automatically when the action pushed them to Gerrit
+- Users had to explicitly set `PRESERVE_GITHUB_PRS="true"` to keep PRs open
+
+**New Behavior (v0.2.0):**
+
+- Default: `PRESERVE_GITHUB_PRS="true"`
+- GitHub pull requests now remain open by default when the action pushes them to Gerrit
+- Users must explicitly set `PRESERVE_GITHUB_PRS="false"` to close PRs after submission
+
+**Rationale:**
+
+We changed the default for these reasons:
+
+1. **Common Use Case**: Most projects using this action want to maintain GitHub
+   PRs as a reference point even after they submit changes to Gerrit
+2. **Safer Default**: Preserving PRs is a non-destructive operation, making it a safer default behavior
+3. **Alignment with Documentation**: The README already recommended
+   `PRESERVE_GITHUB_PRS=true` as the typical configuration
+4. **Two-Way Workflow**: The new `CLOSE_MERGED_PRS` feature (default: `true`)
+   closes PRs automatically when maintainers merge Gerrit changes, offering a
+   complete bidirectional workflow
+
+**Migration Guide:**
+
+If your workflow relied on the previous default behavior of closing PRs after submission:
+
+```yaml
+# Add this to your workflow to maintain v0.1.x behavior
+- uses: lfit/github2gerrit-action@v0.2.0
+  with:
+    PRESERVE_GITHUB_PRS: "false"
+    # ... other inputs
+```
+
+If you want to use the new recommended workflow:
+
+```yaml
+# Use defaults for v0.2.0 - PRs stay open until Gerrit merge
+- uses: lfit/github2gerrit-action@v0.2.0
+  with:
+    PRESERVE_GITHUB_PRS: "true"   # Default, you can omit this line
+    CLOSE_MERGED_PRS: "true"       # Default, you can omit this line
+    # ... other inputs
+```
+
+## New Features
+
+### Enhanced Push Event Handling
+
+**Improved Documentation and State Management:**
+
+- Push events now explicitly set `PR_NUMBER` to empty string to show intentional absence
+- Added inline documentation explaining that push events use `_process_close_merged_prs()` for PR closure
+- Downstream steps can now reliably detect push event processing mode
+
+**Technical Details:**
+
+```yaml
+# Push events don't need PR_NUMBER (used for closing merged PRs)
+# The CLI handles push events specially via _process_close_merged_prs()
+if [[ "${{ github.event_name }}" == "push" ]]; then
+  echo "Push event detected - will process merged commits for PR closure"
+  # Set PR_NUMBER to empty to show this is intentional for push events
+  echo "PR_NUMBER=" >> "$GITHUB_ENV"
+  exit 0
+fi
+```
+
+## Code Quality Improvements
+
+### Simplified Exception Handling
+
+**Refactored `_parse_github_target()` function:**
+
+- Removed unnecessary `else` clause from try-except block
+- Return statement now executes right after successful PR number parsing
+- Improved code readability and maintainability
+
+**Before:**
+
+```python
+try:
+    pr_number = int(parts[3])
+except Exception:
+    pr_number = None
+else:
+    return "github_pr", owner, repo, pr_number
+```
+
+**After:**
+
+```python
+try:
+    pr_number = int(parts[3])
+    return "github_pr", owner, repo, pr_number
+except Exception:
+    pr_number = None
+```
+
+### Type-Safe URL Parsing with Discriminated Union
+
+**Refactored URL parsing to use dataclasses:**
+
+- Replaced tuple-based return types with proper dataclasses
+- Created `GitHubPRTarget`, `GitHubRepoTarget`, and `GerritChangeTarget` types
+- Improved type safety and API clarity
+- Pattern matching with `isinstance()` for better code readability
+
+**Before:**
+
+```python
+def _parse_target_url(url: str) -> tuple[str, str | None, str | None, int | str | None]:
+    """Parse a GitHub or Gerrit URL."""
+    if re.match(GERRIT_CHANGE_URL_PATTERN, url):
+        return (
+            "gerrit_change",
+            None,  # owner
+            None,  # repo
+            url    # change_url
+        )
+    return _parse_github_target(url)
+
+# Usage
+url_type, org, repo, pr_or_change = _parse_target_url(target_url)
+if url_type == "gerrit_change":
+    # Handle Gerrit URL
+```
+
+**After:**
+
+```python
+@dataclass(frozen=True)
+class GitHubPRTarget:
+    owner: str | None
+    repo: str | None
+    pr_number: int | None
+
+@dataclass(frozen=True)
+class GitHubRepoTarget:
+    owner: str | None
+    repo: str | None
+
+@dataclass(frozen=True)
+class GerritChangeTarget:
+    change_url: str
+
+TargetURL = GitHubPRTarget | GitHubRepoTarget | GerritChangeTarget
+
+def _parse_target_url(url: str) -> TargetURL:
+    """Parse a GitHub or Gerrit URL into a type-safe result."""
+    if re.match(GERRIT_CHANGE_URL_PATTERN, url):
+        return GerritChangeTarget(change_url=url)
+    return _parse_github_target(url)
+
+# Usage
+parsed = _parse_target_url(target_url)
+if isinstance(parsed, GerritChangeTarget):
+    # Handle Gerrit URL with type safety
+    change_url = parsed.change_url
+```
+
+**Benefits:**
+
+- **Type Safety**: Static type checkers can verify correct usage
+- **Clear API**: No ambiguity about what the 4th tuple element contains
+- **Better IDE Support**: Autocomplete and type hints work as expected
+- **Immutability**: Frozen dataclasses prevent accidental modifications
+- **Self-Documenting**: Class names show the URL type
+
+### Improved Progress Tracker Type Safety
+
+**Refactored progress tracker typing:**
+
+- Replaced `Any` type with proper union types: `G2GProgressTracker | DummyProgressTracker | None`
+- Made `None` checks explicit where the parameter accepts `None`
+- Removed unnecessary null checks where tracker is always initialized
+- Improved type safety for better IDE support and static analysis
+
+**Before:**
+
+```python
+def _process_close_merged_prs(data: Inputs, gh: GitHubContext) -> None:
+    show_progress = env_bool("G2G_SHOW_PROGRESS", True)
+    progress_tracker: Any = None  # Type is too broad
+
+    if show_progress:
+        progress_tracker = G2GProgressTracker(target)
+    else:
+        progress_tracker = DummyProgressTracker("Gerrit PR Closer", target)
+
+    # Unnecessary null check - always assigned above
+    if progress_tracker:
+        progress_tracker.update_operation("...")
+```
+
+**After:**
+
+```python
+def _process_close_merged_prs(data: Inputs, gh: GitHubContext) -> None:
+    show_progress = env_bool("G2G_SHOW_PROGRESS", True)
+
+    # Explicit union type, no None needed here
+    progress_tracker: G2GProgressTracker | DummyProgressTracker
+    if show_progress:
+        progress_tracker = G2GProgressTracker(target)
+    else:
+        progress_tracker = DummyProgressTracker("Gerrit PR Closer", target)
+
+    # Direct call - no null check needed
+    progress_tracker.update_operation("...")
+```
+
+**For functions accepting tracker as parameter:**
+
+```python
+def _process_single(
+    data: Inputs,
+    gh: GitHubContext,
+    progress_tracker: G2GProgressTracker | DummyProgressTracker | None = None,
+) -> tuple[bool, SubmissionResult]:
+    # None check where parameter can accept None
+    if progress_tracker:
+        progress_tracker.update_operation("...")
+```
+
+**Benefits:**
+
+- Better static type checking with mypy/pyright
+- Intent is explicit: shows when None is possible
+- Removes dead code from unnecessary null checks
+- Improved IDE autocomplete and refactoring support
+
+### Respect User Flags for Gerrit Change URLs
+
+**Fixed flag override issue:**
+
+- When the user provided a Gerrit change URL, the code unconditionally set `CLOSE_MERGED_PRS` to `true`
+- The action now respects the user's explicit `--close-merged-prs` flag value
+- Provides better user control over PR closure behavior
+
+**Behavior with flag:**
+
+- `--close-merged-prs=true` (default): Closes the GitHub PR when processing Gerrit change
+- `--close-merged-prs=false`: Adds a comment to the PR but leaves it open
+
+**Before:**
+
+```python
+if isinstance(parsed, GerritChangeTarget):
+    # Always forced to true, ignoring user preference
+    os.environ["CLOSE_MERGED_PRS"] = "true"
+    os.environ["G2G_GERRIT_CHANGE_URL"] = parsed.change_url
+```
+
+**After:**
+
+```python
+if isinstance(parsed, GerritChangeTarget):
+    # Respects user's --close-merged-prs flag set earlier
+    # CLOSE_MERGED_PRS was already set based on user flag at line 812
+    os.environ["G2G_GERRIT_CHANGE_URL"] = parsed.change_url
+    log.debug(
+        "Gerrit change URL mode with CLOSE_MERGED_PRS=%s",
+        os.environ.get("CLOSE_MERGED_PRS", "true")
+    )
+```
+
+**Use cases enabled:**
+
+```bash
+# Close PR when processing Gerrit change (default behavior)
+github2gerrit https://gerrit.example.com/c/project/+/12345
+
+# Add comment to PR without closing it (new capability)
+# Useful for notification workflows or testing
+github2gerrit --close-merged-prs=false https://gerrit.example.com/c/project/+/12345
+```
+
+**Benefits:**
+
+- User intent controls behavior across all code paths
+- Consistent behavior with other CLI flags
+- More flexible workflow options (close vs. comment)
+- Useful for notification workflows
+- Better debugging and testing capabilities
+
+### Improved Gerrit URL Pattern Matching
+
+**More specific and secure regex pattern:**
+
+- Replaced greedy `(?:.*/)?` pattern with explicit `(?:[\w-]+/)*`
+- Better security: prevents unintended matches and path traversal attempts
+- More maintainable: documents what characters we accept in subpaths
+- Comprehensive documentation with examples added to `constants.py`
+
+**Before:**
+
+```python
+# Too greedy - could match unexpected URLs
+GERRIT_CHANGE_URL_PATTERN = r"https?://([^/]+)/(?:.*/)?c/[^+]+/\+/(\d+)"
+```
+
+**After:**
+
+```python
+# More specific - matches word characters and hyphens in subpaths
+# Pattern breakdown documented inline
+GERRIT_CHANGE_URL_PATTERN = r"https?://([^/]+)/(?:[\w-]+/)*c/[^+]+/\+/(\d+)"
+```
+
+**Valid URLs matched:**
+
+```python
+# Standard format
+https://gerrit.example.com/c/project/+/12345
+
+# With subpath (e.g., /infra/, /r/)
+https://gerrit.example.com/infra/c/releng/lftools/+/123
+
+# Nested project names
+https://gerrit.example.com/c/nested/project/name/+/99999
+
+# Subpaths at different levels
+https://gerrit.example.com/sub1/sub2/c/project/+/789
+```
+
+**Invalid URLs rejected:**
+
+```python
+# Missing /c/ indicator
+https://gerrit.example.com/project/+/123  # ✗
+
+# Path traversal attempts
+https://gerrit.example.com/../../c/proj/+/123  # ✗
+
+# Spaces in subpath
+https://gerrit.example.com/bad path/c/proj/+/123  # ✗
+```
+
+**Benefits:**
+
+- Reduced false positive matches
+- Better security posture
+- Intent is explicit through the pattern
+- Comprehensive inline documentation
+- All existing tests continue to pass
+
+### Improved G2G_TARGET_URL Environment Variable
+
+**Enhanced internal flag storage:**
+
+- The code used to set `G2G_TARGET_URL` to `"1"` as a boolean flag when in direct URL mode
+- Now stores the actual URL string (e.g., `"https://github.com/owner/repo/pull/123"`)
+- All downstream code uses truthy/falsy checks, so behavior remains the same
+- Provides better debugging and logging capabilities
+
+**Technical Details:**
+
+```python
+# Now stores actual URL instead of "1"
+os.environ["G2G_TARGET_URL"] = target_url  # e.g., "https://github.com/..."
+os.environ["G2G_TARGET_URL_TYPE"] = url_type
+
+# All usages remain compatible (truthy checks)
+if os.getenv("G2G_TARGET_URL"):  # Works with any non-empty string
+    # ... code
+```
+
+**Benefits:**
+
+- Better debugging: Can see the actual URL in logs and environment dumps
+- Future extensibility: Code can now access the original URL if needed
+- No breaking changes: All boolean checks continue to work as before
+
+## Behavior Summary Table
+
+| Feature | v0.1.x Default | v0.2.0 Default | Notes |
+|---------|----------------|----------------|-------|
+| `PRESERVE_GITHUB_PRS` | `"false"` | `"true"` | **BREAKING CHANGE** |
+| `CLOSE_MERGED_PRS` | `"true"` | `"true"` | No change |
+| Push event handling | Basic | Enhanced | Better state management |
+
+## Recommended Workflow Patterns
+
+### Pattern 1: Preserve PRs, Close on Merge (Recommended)
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, master]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lfit/github2gerrit-action@v0.2.0
+        with:
+          GERRIT_SSH_PRIVKEY_G2G: ${{ secrets.GERRIT_SSH_PRIVKEY_G2G }}
+          # Defaults handle the rest:
+          # - PRESERVE_GITHUB_PRS: "true" keeps PRs open
+          # - CLOSE_MERGED_PRS: "true" closes PRs when merged in Gerrit
+```
+
+### Pattern 2: Close PRs After Submission
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lfit/github2gerrit-action@v0.2.0
+        with:
+          GERRIT_SSH_PRIVKEY_G2G: ${{ secrets.GERRIT_SSH_PRIVKEY_G2G }}
+          PRESERVE_GITHUB_PRS: "false"
+          # No need for push events in this pattern
+```
+
+### Pattern 3: Keep All PRs Open (Reference)
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lfit/github2gerrit-action@v0.2.0
+        with:
+          GERRIT_SSH_PRIVKEY_G2G: ${{ secrets.GERRIT_SSH_PRIVKEY_G2G }}
+          PRESERVE_GITHUB_PRS: "true"
+          CLOSE_MERGED_PRS: "false"
+```
+
+## Upgrade Checklist
+
+When upgrading from v0.1.x to v0.2.0:
+
+- [ ] Review your workflow files for `PRESERVE_GITHUB_PRS` settings
+- [ ] Decide if you want the new default behavior (preserve PRs)
+- [ ] If you want v0.1.x behavior, explicitly set
+  `PRESERVE_GITHUB_PRS: "false"`
+- [ ] Consider enabling push event triggers if using `CLOSE_MERGED_PRS`
+- [ ] Update any documentation or runbooks referencing PR closure behavior
+- [ ] Test in a non-production environment first
+
+## Notes
+
+### Why Two Options?
+
+- **`PRESERVE_GITHUB_PRS`**: Controls whether the action closes PRs right after
+  pushing to Gerrit (on `pull_request_target` events)
+- **`CLOSE_MERGED_PRS`**: Controls whether the action closes PRs when maintainers
+  merge corresponding Gerrit changes (on `push` events)
+
+These options work together to provide flexible workflow patterns:
+
+- Both `true`: PRs stay open during review, close when merged ✅ **Recommended**
+- `PRESERVE=false`, `CLOSE=true`: The action closes PRs right away (v0.1.x default behavior)
+- `PRESERVE=true`, `CLOSE=false`: The action never closes PRs automatically
+- Both `false`: The action closes PRs right away (same as `PRESERVE=false`)
+
+## Test Infrastructure Improvements
+
+### Enhanced Test Environment Isolation
+
+**Comprehensive documentation and fixes for test stability:**
+
+- Documented why `isolate_git_environment` fixture uses `autouse=True`
+- Added explanation of pre-commit hook test failures without isolation
+- Provided module-level documentation in `tests/conftest.py`
+- Included examples for overriding fixture behavior when needed
+
+**Key isolation features:**
+
+```python
+@pytest.fixture(autouse=True)
+def isolate_git_environment(monkeypatch):
+    """
+    ⚠️  IMPORTANT: autouse=True ensures test suite stability
+
+    Why this fixture applies globally:
+    1. Pre-commit Hook Failures: Without this, pytest running from
+       pre-commit hooks resulted in random test failures due to SSH
+       agent state pollution from the host environment.
+
+    2. Cross-Test Contamination: Git operations in one test can affect
+       later tests through shared environment variables.
+
+    3. Non-Deterministic Behavior: Tests can fail if they execute
+       git commands internally or depend on code that does.
+
+    4. CI/CD Consistency: Ensures tests behave identically whether run
+       locally, in GitHub Actions, or via pre-commit hooks.
+    """
+```
+
+**What's protected:**
+
+- SSH agent state isolation (no `SSH_AUTH_SOCK` or `SSH_AGENT_PID` inheritance)
+- Consistent git identity across all tests (`Test Bot <test-bot@example.org>`)
+- Non-interactive SSH configuration for git operations
+- Coverage data isolation (prevents data mixing across test runs)
+- Config file isolation (uses temporary files, not user's config)
+- GitHub CI mode detection disabled during tests
+
+**Common issues prevented:**
+
+- ✓ Random test failures in pre-commit hooks (SSH agent pollution)
+- ✓ Tests passing locally but failing in CI (environment differences)
+- ✓ Coverage data mixing errors (parallel test runs)
+- ✓ Tests reading/writing real user configuration files
+- ✓ Git operations using host SSH keys instead of test keys
+
+**For test authors:**
+All fixtures with `autouse=True` are intentionally global for test stability.
+If you need custom configuration, override specific environment variables
+within your test rather than skipping the fixture.
+
+## Feedback and Support
+
+If you encounter issues or have questions about this release:
+
+- Open an issue: [GitHub Issues](https://github.com/lfit/releng-lftools/issues)
+- Review documentation: [README.md](../README.md)
+- Check examples: [.github/workflows/](../.github/workflows/)
+
+## Contributors
+
+Thank you to all contributors who helped make this release possible!
+
+---
+
+**Full Changelog**: [v0.1.0...v0.2.0](https://github.com/lfit/releng-lftools/compare/v0.1.0...v0.2.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ directory = "coverage_html_report"
 minversion = "8.0"
 addopts = "-ra -q --cov=github2gerrit --cov-report=term-missing --cov-report=html"
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
 ]

--- a/src/github2gerrit/constants.py
+++ b/src/github2gerrit/constants.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Shared constants for github2gerrit."""
+
+# Gerrit change URL pattern
+# Matches URLs with the structure: https://HOST[/SUBPATH]/c/PROJECT/+/NUMBER
+# Examples:
+#   https://gerrit.example.com/c/project/+/12345
+#   https://gerrit.example.com/infra/c/releng/lftools/+/123
+#   https://gerrit.example.com/c/nested/project/name/+/99999
+#
+# Pattern breakdown:
+#   https?://           - Protocol (http or https)
+#   ([^/]+)             - Capture group 1: hostname
+#   /                   - Path separator
+#   (?:[\w-]+/)*        - Optional subpath before /c/ (e.g., /infra/, /r/)
+#                         More specific than .* to avoid greedy matching
+#   c/                  - Gerrit change indicator
+#   [^+]+               - Project name (can contain slashes for nested projects)
+#   /\+/                - Gerrit's +/ separator
+#   (\d+)               - Capture group 2: change number
+GERRIT_CHANGE_URL_PATTERN = r"https?://([^/]+)/(?:[\w-]+/)*c/[^+]+/\+/(\d+)"
+
+# GitHub PR URL pattern (supports both github.com and GitHub Enterprise)
+# Matches URLs like:
+#   https://github.com/owner/repo/pull/123
+#   https://ghe.example.com/owner/repo/pull/123
+GITHUB_PR_URL_PATTERN = r"https?://([^/]+)/([^/]+)/([^/]+)/pull/(\d+)"

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -1037,6 +1037,8 @@ class Orchestrator:
                 # Prefer PR head/base refs via GitHub API when running
                 # from a direct URL when a token is available
                 try:
+                    # When a target URL was provided via CLI, G2G_TARGET_URL
+                    # contains the actual URL string (truthy check)
                     if (
                         gh
                         and gh.pr_number
@@ -1177,6 +1179,8 @@ class Orchestrator:
             if inputs.dry_run:
                 project = repo.project_gerrit
                 log.info("Dry run: using derived Gerrit project '%s'", project)
+            # When a target URL was provided via CLI (G2G_TARGET_URL is set),
+            # use the derived Gerrit project name from the repository
             elif os.getenv("G2G_TARGET_URL", "").strip():
                 project = repo.project_gerrit
                 log.info(

--- a/src/github2gerrit/error_codes.py
+++ b/src/github2gerrit/error_codes.py
@@ -55,6 +55,9 @@ class ExitCode(IntEnum):
     VALIDATION_ERROR = 9
     """Input validation failed."""
 
+    GERRIT_CHANGE_ALREADY_FINAL = 10
+    """Gerrit change is already in a final state (MERGED/ABANDONED)."""
+
 
 # Error message templates
 ERROR_MESSAGES = {
@@ -82,6 +85,9 @@ ERROR_MESSAGES = {
     ),
     ExitCode.VALIDATION_ERROR: (
         "❌ Input validation failed; check parameter values"
+    ),
+    ExitCode.GERRIT_CHANGE_ALREADY_FINAL: (
+        "❌ Gerrit change is already in a final state; use --force to override"
     ),
     ExitCode.GENERAL_ERROR: "❌ Operation failed; check logs for details",
 }

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -1,0 +1,792 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Gerrit PR Closer - handles closing GitHub PRs when Gerrit changes are merged.
+
+This module provides functionality to detect when a Gerrit change has been
+merged and close the corresponding GitHub pull request that originated it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from typing import Literal
+
+from .constants import GERRIT_CHANGE_URL_PATTERN
+from .constants import GITHUB_PR_URL_PATTERN
+from .error_codes import ExitCode
+from .error_codes import GitHub2GerritError
+from .gerrit_rest import GerritRestError
+from .gerrit_rest import build_client_for_host
+from .github_api import build_client
+from .github_api import close_pr
+from .github_api import create_pr_comment
+from .github_api import get_pull
+from .gitutils import git_show
+from .rich_display import display_pr_info
+from .trailers import GITHUB_PR_TRAILER
+from .trailers import parse_trailers
+
+
+log = logging.getLogger(__name__)
+
+
+def extract_change_number_from_url(
+    gerrit_change_url: str,
+) -> tuple[str, str] | None:
+    """
+    Extract Gerrit host and change number from a Gerrit change URL.
+
+    Args:
+        gerrit_change_url: Gerrit change URL (e.g., https://gerrit.example.org/c/project/+/12345)
+
+    Returns:
+        Tuple of (host, change_number) if valid, None otherwise
+
+    Examples:
+        >>> extract_change_number_from_url("https://gerrit.example.org/c/project/+/12345")
+        ('gerrit.example.org', '12345')
+        >>> extract_change_number_from_url("https://gerrit.linuxfoundation.org/infra/c/releng/lftools/+/123")
+        ('gerrit.linuxfoundation.org', '123')
+    """
+    # Use shared pattern from constants module
+    match = re.match(GERRIT_CHANGE_URL_PATTERN, gerrit_change_url)
+
+    if match:
+        host = match.group(1)
+        change_number = match.group(2)
+        return (host, change_number)
+
+    log.debug("Failed to parse Gerrit change URL: %s", gerrit_change_url)
+    return None
+
+
+def check_gerrit_change_status(
+    gerrit_change_url: str,
+) -> Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"]:
+    """
+    Check the status of a Gerrit change via REST API.
+
+    Args:
+        gerrit_change_url: Gerrit change URL
+
+    Returns:
+        Status string: "MERGED", "ABANDONED", "NEW", or "UNKNOWN"
+
+    Note:
+        This function logs warnings but does not raise exceptions on
+        API failures. Returns "UNKNOWN" if status cannot be determined.
+    """
+    parsed = extract_change_number_from_url(gerrit_change_url)
+    if not parsed:
+        log.warning(
+            "Cannot extract change number from URL: %s",
+            gerrit_change_url,
+        )
+        return "UNKNOWN"
+
+    host, change_number = parsed
+
+    try:
+        # Build Gerrit REST client for the host
+        client = build_client_for_host(host)
+
+        # Query change details
+        # Gerrit REST API endpoint: GET /changes/{change-id}
+        change_data = client.get(f"/changes/{change_number}")
+
+        # Extract status from response
+        status = change_data.get("status", "UNKNOWN")
+        log.debug("Gerrit change %s status: %s", change_number, status)
+    except GerritRestError as exc:
+        log.warning(
+            "Failed to query Gerrit change %s status: %s",
+            change_number,
+            exc,
+        )
+        return "UNKNOWN"
+    except Exception as exc:
+        log.warning(
+            "Unexpected error querying Gerrit change %s: %s",
+            change_number,
+            exc,
+        )
+        return "UNKNOWN"
+    else:
+        # Validate status against allowed values for type safety
+        allowed_statuses = ("MERGED", "ABANDONED", "NEW", "UNKNOWN")
+        result: Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"] = (
+            status if status in allowed_statuses else "UNKNOWN"
+        )
+        if status not in allowed_statuses:
+            log.warning(
+                "Unexpected Gerrit status '%s' for change %s, "
+                "treating as UNKNOWN",
+                status,
+                change_number,
+            )
+        return result
+
+
+def extract_pr_url_from_commit(commit_sha: str) -> str | None:
+    """
+    Extract GitHub PR URL from a commit's trailers.
+
+    Args:
+        commit_sha: Git commit SHA to inspect
+
+    Returns:
+        GitHub PR URL if found, None otherwise
+    """
+    try:
+        # Get the commit message
+        commit_message = git_show(commit_sha, fmt="%B")
+
+        # Parse trailers
+        trailers = parse_trailers(commit_message)
+
+        # Look for GitHub-PR trailer
+        pr_urls = trailers.get(GITHUB_PR_TRAILER, [])
+        if pr_urls:
+            pr_url = pr_urls[-1]  # Take the last one if multiple exist
+            log.debug("Found GitHub-PR trailer: %s", pr_url)
+            return pr_url
+        else:
+            log.debug("No GitHub-PR trailer found in commit %s", commit_sha[:8])
+            return None
+
+    except Exception as exc:
+        log.debug(
+            "Failed to extract PR URL from commit %s: %s",
+            commit_sha[:8],
+            exc,
+        )
+        return None
+
+
+def parse_pr_url(pr_url: str) -> tuple[str, str, int] | None:
+    """
+    Parse a GitHub PR URL to extract owner, repo, and PR number.
+
+    Args:
+        pr_url: GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+
+    Returns:
+        Tuple of (owner, repo, pr_number) if valid, None otherwise
+    """
+    # Use shared pattern from constants module (supports GHE)
+    match = re.match(GITHUB_PR_URL_PATTERN, pr_url)
+
+    if match:
+        host = match.group(1)  # GitHub host (github.com or GHE domain)
+
+        # Exclude known non-GitHub hosts
+        bad_hosts = {
+            "gitlab.com",
+            "www.gitlab.com",
+            "bitbucket.org",
+            "www.bitbucket.org",
+        }
+        if host in bad_hosts:
+            log.debug("Rejected non-GitHub host: %s", host)
+            return None
+
+        owner = match.group(2)
+        repo = match.group(3)
+        pr_number = int(match.group(4))
+        return (owner, repo, pr_number)
+
+    log.debug("Failed to parse PR URL: %s", pr_url)
+    return None
+
+
+def extract_pr_url_from_gerrit_change(gerrit_change_url: str) -> str | None:
+    """
+    Extract GitHub PR URL from a Gerrit change by querying the Gerrit API.
+
+    This function queries the Gerrit REST API to get the commit message,
+    then extracts the GitHub-PR trailer.
+
+    Args:
+        gerrit_change_url: Full Gerrit change URL (e.g., https://gerrit.example.com/c/project/+/12345)
+
+    Returns:
+        GitHub PR URL if found in commit trailers, None otherwise
+    """
+    parsed = extract_change_number_from_url(gerrit_change_url)
+    if not parsed:
+        log.debug(
+            "Cannot extract change number from URL: %s",
+            gerrit_change_url,
+        )
+        return None
+
+    host, change_number = parsed
+
+    try:
+        # Build Gerrit REST client for the host
+        client = build_client_for_host(host)
+
+        # Query change details including commit message
+        # Gerrit REST API endpoint: GET /changes/{change-id}/detail
+        change_data = client.get(f"/changes/{change_number}/detail")
+
+        # Get the current revision (latest patchset)
+        current_revision = change_data.get("current_revision")
+        if not current_revision:
+            log.debug("No current revision found for change %s", change_number)
+            return None
+
+        # Get commit message from the revision data
+        revisions = change_data.get("revisions", {})
+        revision_data = revisions.get(current_revision, {})
+        commit_data = revision_data.get("commit", {})
+        commit_message = commit_data.get("message", "")
+
+        if not commit_message:
+            log.debug("No commit message found for change %s", change_number)
+            return None
+
+        # Parse trailers to find GitHub-PR URL
+        trailers = parse_trailers(commit_message)
+        pr_urls = trailers.get(GITHUB_PR_TRAILER, [])
+
+        if pr_urls:
+            pr_url = pr_urls[-1]  # Take the last one if multiple exist
+            log.debug("Found GitHub-PR trailer in Gerrit change: %s", pr_url)
+            return pr_url
+    except GerritRestError as exc:
+        log.warning(
+            "Failed to query Gerrit change %s: %s",
+            change_number,
+            exc,
+        )
+        return None
+    except Exception as exc:
+        log.warning(
+            "Unexpected error querying Gerrit change %s: %s",
+            change_number,
+            exc,
+        )
+        return None
+    else:
+        # No PR URL found in trailers
+        log.debug(
+            "No GitHub-PR trailer found in Gerrit change %s",
+            change_number,
+        )
+        return None
+
+
+def extract_pr_info_for_display(
+    pr_obj: Any,
+    owner: str,
+    repo: str,
+    pr_number: int,
+) -> dict[str, Any]:
+    """
+    Extract PR information for display in a formatted table.
+
+    Args:
+        pr_obj: GitHub PR object
+        owner: Repository owner
+        repo: Repository name
+        pr_number: PR number
+
+    Returns:
+        Dictionary of PR information for display
+    """
+    try:
+        # Get PR title
+        title = getattr(pr_obj, "title", "No title")
+
+        # Get PR author
+        author = "Unknown"
+        user = getattr(pr_obj, "user", None)
+        if user:
+            author = getattr(user, "login", "Unknown") or "Unknown"
+
+        # Get base branch
+        base_branch = "unknown"
+        base = getattr(pr_obj, "base", None)
+        if base:
+            base_branch = getattr(base, "ref", "unknown") or "unknown"
+
+        # Get SHA
+        sha = "unknown"
+        head = getattr(pr_obj, "head", None)
+        if head:
+            sha = getattr(head, "sha", "unknown") or "unknown"
+
+        # Build PR info dictionary
+        pr_info = {
+            "Repository": f"{owner}/{repo}",
+            "PR Number": pr_number,
+            "Title": title or "No title",
+            "Author": author,
+            "Base Branch": base_branch,
+            "SHA": sha,
+            "URL": f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+        }
+
+        # Add file changes count if available
+        try:
+            files = list(getattr(pr_obj, "get_files", list)())
+            pr_info["Files Changed"] = len(files)
+        except Exception:
+            pr_info["Files Changed"] = "unknown"
+
+    except Exception as exc:
+        log.debug("Failed to extract PR info for display: %s", exc)
+        raise GitHub2GerritError(
+            ExitCode.GITHUB_API_ERROR,
+            message="Failed to extract PR information",
+            details=f"PR #{pr_number} in {owner}/{repo}",
+            original_exception=exc,
+        ) from exc
+    else:
+        return pr_info
+
+
+def close_pr_with_status(
+    pr_url: str,
+    gerrit_change_url: str | None,
+    gerrit_status: Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"],
+    *,
+    dry_run: bool = False,
+    progress_tracker: Any = None,
+    close_merged_prs: bool = True,
+) -> bool:
+    """
+    Close a GitHub PR based on Gerrit change status.
+
+    This is a public helper function that consolidates the PR closing logic
+    used by multiple functions across the codebase.
+
+    Args:
+        pr_url: GitHub PR URL
+        gerrit_change_url: Gerrit change URL for the comment
+        gerrit_status: Status of the Gerrit change
+        dry_run: If True, only display info without closing the PR
+        progress_tracker: Optional progress tracker for display management
+        close_merged_prs: If True, close PRs; if False, only comment on
+            abandoned
+
+    Returns:
+        True if PR was closed (or would be closed in dry-run), False otherwise
+    """
+    # Parse PR URL
+    parsed = parse_pr_url(pr_url)
+    if not parsed:
+        log.info("Invalid GitHub PR URL format: %s - skipping", pr_url)
+        return False
+
+    owner, repo, pr_number = parsed
+    log.info("Found GitHub PR: %s/%s#%d", owner, repo, pr_number)
+
+    try:
+        # Build GitHub client and get repository
+        client = build_client()
+
+        # Get the specific repository (not from env, might be different)
+        repo_obj = client.get_repo(f"{owner}/{repo}")
+
+        # Fetch the pull request
+        try:
+            pr_obj = get_pull(repo_obj, pr_number)
+        except Exception as exc:
+            # PR not found or API error - log as info, not error
+            if "404" in str(exc) or "Not Found" in str(exc):
+                log.info(
+                    "GitHub PR #%d not found in %s/%s - may have been deleted",
+                    pr_number,
+                    owner,
+                    repo,
+                )
+            else:
+                # Other API errors should still be logged but not fatal
+                log.warning(
+                    "Could not fetch GitHub PR #%d: %s - skipping",
+                    pr_number,
+                    exc,
+                )
+            return False
+
+        # Check if PR is already closed
+        pr_state = getattr(pr_obj, "state", "unknown")
+        if pr_state == "closed":
+            log.info(
+                "GitHub PR #%d is already closed - nothing to do",
+                pr_number,
+            )
+            return False
+
+        # Extract and display PR information
+        pr_info = extract_pr_info_for_display(pr_obj, owner, repo, pr_number)
+        display_pr_info(pr_info, "Pull Request Details", progress_tracker)
+
+        # Determine action based on Gerrit status and close_merged_prs setting
+        should_close = False
+        comment = ""
+
+        if gerrit_status == "ABANDONED":
+            if close_merged_prs:
+                # Close PR with abandoned comment
+                should_close = True
+                comment = _build_abandoned_comment(gerrit_change_url)
+            else:
+                # Comment only, don't close
+                should_close = False
+                comment = _build_abandoned_notification_comment(
+                    gerrit_change_url
+                )
+        else:
+            # For MERGED, NEW, or UNKNOWN status with close_merged_prs=True
+            if close_merged_prs:
+                should_close = True
+                comment = _build_closure_comment(gerrit_change_url)
+            else:
+                # close_merged_prs=False, don't close for merged either
+                log.info(
+                    "Skipping PR closure (CLOSE_MERGED_PRS=false) for "
+                    "status: %s",
+                    gerrit_status,
+                )
+                return False
+
+        if dry_run:
+            if should_close:
+                log.info("DRY-RUN: Would close PR #%d with comment", pr_number)
+            else:
+                log.info(
+                    "DRY-RUN: Would comment on PR #%d (not close)", pr_number
+                )
+            return True
+
+        # Add comment and optionally close the PR
+        if should_close:
+            log.info("Closing GitHub PR #%d...", pr_number)
+            close_pr(pr_obj, comment=comment)
+            log.info("SUCCESS: Closed GitHub PR #%d", pr_number)
+        else:
+            # Comment only, don't close
+            log.info(
+                "Adding abandoned notification comment to PR #%d...", pr_number
+            )
+            create_pr_comment(pr_obj, comment)
+            log.info(
+                "SUCCESS: Added comment to PR #%d (PR remains open)", pr_number
+            )
+
+    except GitHub2GerritError as exc:
+        # Our structured errors - log as warning but don't fail the workflow
+        log.warning(
+            "Could not close GitHub PR #%d: %s - skipping",
+            pr_number,
+            exc.message,
+        )
+        return False
+    except Exception as exc:
+        # Catch unexpected errors with detailed context for debugging
+        # Common cases: network issues, auth failures, API rate limits
+        error_type = type(exc).__name__
+        error_details = str(exc)
+
+        # Check for common error patterns
+        if "401" in error_details or "403" in error_details:
+            log.exception(
+                "Authentication/authorization error while closing PR #%d: "
+                "%s - check GitHub token permissions",
+                pr_number,
+                error_details,
+            )
+        elif "404" in error_details:
+            log.warning(
+                "PR #%d not found or repository inaccessible: %s",
+                pr_number,
+                error_details,
+            )
+        elif "rate limit" in error_details.lower():
+            log.exception(
+                "GitHub API rate limit exceeded while processing PR #%d: %s",
+                pr_number,
+                error_details,
+            )
+        else:
+            # Log with full traceback for unexpected errors
+            log.exception(
+                "Unexpected error (%s) while closing PR #%d: %s",
+                error_type,
+                pr_number,
+                error_details,
+            )
+
+        return False
+    else:
+        return True
+
+
+def close_github_pr_for_merged_gerrit_change(
+    commit_sha: str,
+    gerrit_change_url: str | None = None,
+    *,
+    dry_run: bool = False,
+    progress_tracker: Any = None,
+    close_merged_prs: bool = True,
+) -> bool:
+    """
+    Close a GitHub PR when its corresponding Gerrit change has been
+    merged or abandoned.
+
+    This function:
+    1. Extracts the GitHub PR URL from the commit's trailers
+    2. Verifies the Gerrit change status (merged/abandoned/new/unknown)
+    3. Delegates to _close_pr_with_status for the actual closing logic
+
+    Args:
+        commit_sha: Git commit SHA that was merged in Gerrit
+        gerrit_change_url: Optional Gerrit change URL for the comment
+        dry_run: If True, only display info without closing the PR
+        progress_tracker: Optional progress tracker for display management
+        close_merged_prs: If True, close PRs; if False, only comment on
+            abandoned
+
+    Returns:
+        True if PR was closed (or would be closed in dry-run), False otherwise
+    """
+    log.info("Processing Gerrit change: %s", commit_sha[:8])
+
+    # Check Gerrit change status
+    gerrit_status: Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"] = "UNKNOWN"
+    if gerrit_change_url:
+        gerrit_status = check_gerrit_change_status(gerrit_change_url)
+
+        if gerrit_status == "ABANDONED":
+            if close_merged_prs:
+                log.info(
+                    "Gerrit change was ABANDONED; will close PR with "
+                    "abandoned comment (CLOSE_MERGED_PRS=true)"
+                )
+            else:
+                log.info(
+                    "Gerrit change was ABANDONED; will comment on PR only "
+                    "(CLOSE_MERGED_PRS=false)"
+                )
+        elif gerrit_status == "NEW":
+            log.warning(
+                "Gerrit change is still NEW (not merged yet), but "
+                "proceeding to close PR"
+            )
+        elif gerrit_status == "UNKNOWN":
+            log.warning(
+                "Cannot verify Gerrit change status; proceeding with PR closure"
+            )
+        elif gerrit_status == "MERGED":
+            log.debug("Gerrit change confirmed as MERGED")
+
+    # Extract PR URL from commit
+    pr_url = extract_pr_url_from_commit(commit_sha)
+    if not pr_url:
+        log.info(
+            "No GitHub PR URL found in commit %s - skipping",
+            commit_sha[:8],
+        )
+        return False
+
+    # Delegate to helper function for the actual closing logic
+    return close_pr_with_status(
+        pr_url=pr_url,
+        gerrit_change_url=gerrit_change_url,
+        gerrit_status=gerrit_status,
+        dry_run=dry_run,
+        progress_tracker=progress_tracker,
+        close_merged_prs=close_merged_prs,
+    )
+
+
+def _build_closure_comment(gerrit_change_url: str | None = None) -> str:
+    """
+    Build the comment to post when closing a GitHub PR.
+
+    Args:
+        gerrit_change_url: Optional Gerrit change URL to include in comment
+
+    Returns:
+        Comment text
+    """
+    comment_lines = [
+        "**Automated PR Closure**",
+        "",
+        "This pull request has been automatically closed by GitHub2Gerrit.",
+        "",
+    ]
+
+    if gerrit_change_url:
+        comment_lines.extend(
+            [
+                f"The corresponding Gerrit change has been **merged**: "
+                f"{gerrit_change_url}",
+                "",
+            ]
+        )
+    else:
+        comment_lines.extend(
+            [
+                "The corresponding Gerrit change has been **merged**.",
+                "",
+            ]
+        )
+
+    comment_lines.extend(
+        [
+            (
+                "The changes from this PR are now part of the main codebase "
+                "via Gerrit."
+            ),
+            "",
+            "---",
+            (
+                "*This is an automated action performed by the "
+                "GitHub2Gerrit tool.*"
+            ),
+        ]
+    )
+
+    return "\n".join(comment_lines)
+
+
+def _build_abandoned_comment(gerrit_change_url: str | None = None) -> str:
+    """
+    Build the comment to post when closing a GitHub PR for an abandoned
+    Gerrit change.
+
+    Args:
+        gerrit_change_url: Optional Gerrit change URL to include in comment
+
+    Returns:
+        Comment text
+    """
+    comment_lines = [
+        "**Gerrit Change Abandoned** 🏳️",
+        "",
+        "The corresponding Gerrit change has been **abandoned**.",
+        "",
+    ]
+
+    if gerrit_change_url:
+        comment_lines.extend(
+            [
+                f"Gerrit change URL: {gerrit_change_url}",
+                "",
+            ]
+        )
+
+    comment_lines.extend(
+        [
+            (
+                "This pull request is being closed because the Gerrit review "
+                "was abandoned and `CLOSE_MERGED_PRS` is enabled."
+            ),
+            "",
+            "---",
+            (
+                "*This is an automated action performed by the "
+                "GitHub2Gerrit tool.*"
+            ),
+        ]
+    )
+
+    return "\n".join(comment_lines)
+
+
+def _build_abandoned_notification_comment(
+    gerrit_change_url: str | None = None,
+) -> str:
+    """
+    Build a notification comment when a Gerrit change is abandoned but PR
+    stays open.
+
+    Args:
+        gerrit_change_url: Optional Gerrit change URL to include in comment
+
+    Returns:
+        Comment text
+    """
+    comment_lines = [
+        "**Gerrit Change Abandoned** 🏳️",
+        "",
+        "The corresponding Gerrit change has been **abandoned**.",
+        "",
+    ]
+
+    if gerrit_change_url:
+        comment_lines.extend(
+            [
+                f"Gerrit change URL: {gerrit_change_url}",
+                "",
+            ]
+        )
+
+    comment_lines.extend(
+        [
+            (
+                "This pull request remains open because `CLOSE_MERGED_PRS` "
+                "is disabled."
+            ),
+            "",
+            "---",
+            (
+                "*This is an automated notification from the "
+                "GitHub2Gerrit tool.*"
+            ),
+        ]
+    )
+
+    return "\n".join(comment_lines)
+
+
+def process_recent_commits_for_pr_closure(
+    commit_shas: list[str],
+    *,
+    dry_run: bool = False,
+    progress_tracker: Any = None,
+    close_merged_prs: bool = True,
+) -> int:
+    """
+    Process a list of recent commits and close any associated GitHub PRs.
+
+    This is useful when multiple commits have been pushed from Gerrit.
+
+    Args:
+        commit_shas: List of commit SHAs to process
+        dry_run: If True, only display info without closing PRs
+        progress_tracker: Optional progress tracker for display management
+        close_merged_prs: If True, close PRs; if False, only comment on
+            abandoned
+
+    Returns:
+        Number of PRs closed (or that would be closed in dry-run)
+    """
+    if not commit_shas:
+        log.debug("No commits to process")
+        return 0
+
+    log.info("Processing %d commit(s) for PR closure", len(commit_shas))
+
+    closed_count = 0
+    for commit_sha in commit_shas:
+        # The close function already handles errors gracefully and returns
+        # False. No need for try/except here as it won't raise exceptions
+        if close_github_pr_for_merged_gerrit_change(
+            commit_sha,
+            dry_run=dry_run,
+            progress_tracker=progress_tracker,
+            close_merged_prs=close_merged_prs,
+        ):
+            closed_count += 1
+
+    log.info("Closed %d GitHub PR(s)", closed_count)
+    return closed_count

--- a/tests/fixtures/make_repo.py
+++ b/tests/fixtures/make_repo.py
@@ -82,7 +82,24 @@ def _run_git(
         shell=False,  # inputs are controlled in tests
     )
     if check and proc.returncode != 0:
-        raise RuntimeError()
+        cmd_str = " ".join(full_cmd)
+        stderr = (
+            proc.stderr.decode("utf-8", errors="replace")
+            if proc.stderr is not None and isinstance(proc.stderr, bytes)
+            else proc.stderr
+        )
+        stdout = (
+            proc.stdout.decode("utf-8", errors="replace")
+            if proc.stdout is not None and isinstance(proc.stdout, bytes)
+            else proc.stdout
+        )
+        raise RuntimeError(
+            f"Git command failed: {cmd_str}\n"
+            f"Return code: {proc.returncode}\n"
+            f"Working directory: {cwd}\n"
+            f"stdout: {stdout}\n"
+            f"stderr: {stderr}"
+        )
     return proc
 
 

--- a/tests/test_action_environment_mapping.py
+++ b/tests/test_action_environment_mapping.py
@@ -375,7 +375,7 @@ class TestEnvironmentDefaults:
             "ORGANIZATION": "${{ github.repository_owner }}",
             "REVIEWERS_EMAIL": "",
             "ALLOW_GHE_URLS": "false",
-            "PRESERVE_GITHUB_PRS": "false",
+            "PRESERVE_GITHUB_PRS": "true",
             "DRY_RUN": "false",
             "ALLOW_DUPLICATES": "false",
             "CI_TESTING": "false",

--- a/tests/test_automation_only.py
+++ b/tests/test_automation_only.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from github2gerrit.cli import _check_automation_only
+from github2gerrit.models import GitHubContext
+
+
+class TestAutomationOnly:
+    """Test suite for automation_only feature."""
+
+    def test_automation_only_disabled_allows_all_prs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When automation_only is disabled, all PRs should be allowed."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "false")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "regular-user"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    def test_dependabot_pr_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dependabot PRs should be allowed when automation_only is enabled."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "dependabot[bot]"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    def test_precommit_ci_pr_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pre-commit.ci PRs should be allowed when automation_only is enabled."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "pre-commit-ci[bot]"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    @patch("github2gerrit.github_api.close_pr")
+    def test_regular_user_pr_rejected(
+        self, mock_close_pr: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regular user PRs should be rejected when automation_only is enabled."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "regular-user"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should raise GitHub2GerritError after closing PR
+        with pytest.raises(SystemExit):
+            _check_automation_only(mock_pr, gh)
+
+        # Verify PR was closed with correct comment
+        mock_close_pr.assert_called_once()
+        call_args = mock_close_pr.call_args
+        assert call_args[0][0] == mock_pr
+        comment = call_args[1]["comment"]
+        assert "GitHub mirror does not accept pull requests" in comment
+        assert "Gerrit server" in comment
+
+    def test_missing_author_allows_pr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PRs with missing author should be allowed (with warning)."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user = None
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    def test_dependabot_without_bot_suffix_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dependabot without [bot] suffix should be allowed."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "dependabot"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    def test_precommit_ci_without_bot_suffix_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pre-commit-ci without [bot] suffix should be allowed."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "pre-commit-ci"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
+    @patch("github2gerrit.github_api.close_pr")
+    def test_close_pr_comment_format(
+        self, mock_close_pr: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify the exact format of the close PR comment."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "some-user"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=42,
+        )
+
+        # Should raise SystemExit after closing PR
+        with pytest.raises(SystemExit):
+            _check_automation_only(mock_pr, gh)
+
+        # Verify exact comment format
+        call_args = mock_close_pr.call_args
+        comment = call_args[1]["comment"]
+        expected_lines = [
+            "This GitHub mirror does not accept pull requests.",
+            "Please submit changes to the project's Gerrit server.",
+        ]
+        for line in expected_lines:
+            assert line in comment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,7 +104,7 @@ def _base_env(tmp_path: Path) -> dict[str, str]:
         "REVIEWERS_EMAIL": "",
         # Boolean flags
         "DRY_RUN": "false",
-        "PRESERVE_GITHUB_PRS": "false",
+        "PRESERVE_GITHUB_PRS": "true",
         "ALLOW_DUPLICATES": "false",
         "CI_TESTING": "false",
         # GitHub context

--- a/tests/test_cli_outputs_file.py
+++ b/tests/test_cli_outputs_file.py
@@ -81,6 +81,8 @@ def _base_env_with_event(tmp_path: Path) -> dict[str, str]:
         "GITHUB_HEAD_REF": "feature",
         # Ensure real execution path (not short-circuited)
         "G2G_TEST_MODE": "false",
+        # Disable automation-only mode for tests
+        "AUTOMATION_ONLY": "false",
     }
 
 

--- a/tests/test_cli_url_and_dryrun.py
+++ b/tests/test_cli_url_and_dryrun.py
@@ -31,6 +31,8 @@ def _base_env() -> dict[str, str]:
         # Token not needed since we mock build_client for bulk mode
         "GITHUB_TOKEN": "dummy",
         "DRY_RUN": "true",
+        # Disable automation-only mode for tests
+        "AUTOMATION_ONLY": "false",
     }
 
 

--- a/tests/test_composite_action_coverage.py
+++ b/tests/test_composite_action_coverage.py
@@ -157,7 +157,7 @@ def default_inputs():
         "ORGANIZATION": "test-org",
         "REVIEWERS_EMAIL": "",
         "ALLOW_GHE_URLS": "false",
-        "PRESERVE_GITHUB_PRS": "false",
+        "PRESERVE_GITHUB_PRS": "true",
         "DRY_RUN": "false",
         "ALLOW_DUPLICATES": "false",
         "CI_TESTING": "false",
@@ -647,7 +647,7 @@ class TestIntegrationScenarios:
 
         # Should have sensible defaults for PR workflow
         assert inputs["SUBMIT_SINGLE_COMMITS"]["default"] == "false"
-        assert inputs["PRESERVE_GITHUB_PRS"]["default"] == "false"
+        assert inputs["PRESERVE_GITHUB_PRS"]["default"] == "true"
         assert inputs["DRY_RUN"]["default"] == "false"
 
     def test_dry_run_capability(self, action_tester):

--- a/tests/test_force_flag_cli.py
+++ b/tests/test_force_flag_cli.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Tests for the --force flag in CLI when processing Gerrit change URLs.
+
+The force flag should:
+- WITHOUT --force: Reject MERGED/ABANDONED Gerrit changes with an error
+- WITH --force: Allow processing MERGED/ABANDONED Gerrit changes
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from github2gerrit.cli import _process_close_gerrit_change
+from github2gerrit.error_codes import ExitCode
+from github2gerrit.error_codes import GitHub2GerritError
+from github2gerrit.models import GitHubContext
+from github2gerrit.models import Inputs
+
+
+@pytest.fixture
+def mock_inputs():
+    """Create mock Inputs object for testing."""
+    return Inputs(
+        submit_single_commits=False,
+        use_pr_as_commit=False,
+        fetch_depth=10,
+        gerrit_known_hosts="gerrit.example.org ssh-rsa AAAA...",
+        gerrit_ssh_privkey_g2g="-----BEGIN RSA PRIVATE KEY-----\n...",
+        gerrit_ssh_user_g2g="bot",
+        gerrit_ssh_user_g2g_email="bot@example.org",
+        github_token="ghp_test",  # noqa: S106
+        organization="test-org",
+        reviewers_email="reviewer@example.org",
+        preserve_github_prs=False,
+        dry_run=False,
+        normalise_commit=True,
+        gerrit_server="gerrit.example.org",
+        gerrit_server_port=29418,
+        gerrit_project="test/project",
+        issue_id="",
+        issue_id_lookup_json="",
+        allow_duplicates=False,
+        ci_testing=False,
+    )
+
+
+@pytest.fixture
+def mock_github_context():
+    """Create mock GitHubContext for testing."""
+    from pathlib import Path
+
+    return GitHubContext(
+        event_name="workflow_dispatch",
+        event_action="",
+        event_path=Path("/tmp/event.json"),  # noqa: S108
+        repository="test-org/test-repo",
+        repository_owner="test-org",
+        server_url="https://github.com",
+        run_id="123456",
+        sha="abc123",
+        base_ref="main",
+        head_ref="feature-branch",
+        pr_number=None,
+    )
+
+
+class TestForceFlag:
+    """Tests for --force flag behavior with Gerrit change URLs."""
+
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_merged_change_without_force_raises_error(
+        self,
+        mock_check_status,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that MERGED change without --force raises an error."""
+        mock_check_status.return_value = "MERGED"
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        with pytest.raises(GitHub2GerritError) as exc_info:
+            _process_close_gerrit_change(
+                mock_inputs,
+                mock_github_context,
+                gerrit_url,
+                force=False,
+            )
+
+        assert exc_info.value.exit_code == ExitCode.GERRIT_CHANGE_ALREADY_FINAL
+        assert "already MERGED" in str(exc_info.value.message)
+        assert "--force" in str(exc_info.value.message)
+
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_abandoned_change_without_force_raises_error(
+        self,
+        mock_check_status,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that ABANDONED change without --force raises an error."""
+        mock_check_status.return_value = "ABANDONED"
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        with pytest.raises(GitHub2GerritError) as exc_info:
+            _process_close_gerrit_change(
+                mock_inputs,
+                mock_github_context,
+                gerrit_url,
+                force=False,
+            )
+
+        assert exc_info.value.exit_code == ExitCode.GERRIT_CHANGE_ALREADY_FINAL
+        assert "already ABANDONED" in str(exc_info.value.message)
+        assert "--force" in str(exc_info.value.message)
+
+    @patch("github2gerrit.cli.close_pr_with_status")
+    @patch("github2gerrit.cli.parse_pr_url")
+    @patch("github2gerrit.cli.extract_pr_url_from_gerrit_change")
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_merged_change_with_force_proceeds(
+        self,
+        mock_check_status,
+        mock_extract_pr,
+        mock_parse_pr,
+        mock_close_pr,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that MERGED change with --force proceeds successfully."""
+        mock_check_status.return_value = "MERGED"
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_pr.return_value = ("owner", "repo", 123)
+        mock_close_pr.return_value = None
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should not raise an error
+        _process_close_gerrit_change(
+            mock_inputs,
+            mock_github_context,
+            gerrit_url,
+            force=True,
+        )
+
+        # Verify PR closure was attempted
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.cli.close_pr_with_status")
+    @patch("github2gerrit.cli.parse_pr_url")
+    @patch("github2gerrit.cli.extract_pr_url_from_gerrit_change")
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_abandoned_change_with_force_proceeds(
+        self,
+        mock_check_status,
+        mock_extract_pr,
+        mock_parse_pr,
+        mock_close_pr,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that ABANDONED change with --force proceeds successfully."""
+        mock_check_status.return_value = "ABANDONED"
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_pr.return_value = ("owner", "repo", 123)
+        mock_close_pr.return_value = None
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should not raise an error
+        _process_close_gerrit_change(
+            mock_inputs,
+            mock_github_context,
+            gerrit_url,
+            force=True,
+        )
+
+        # Verify PR closure was attempted
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.cli.close_pr_with_status")
+    @patch("github2gerrit.cli.parse_pr_url")
+    @patch("github2gerrit.cli.extract_pr_url_from_gerrit_change")
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_new_change_proceeds_without_force(
+        self,
+        mock_check_status,
+        mock_extract_pr,
+        mock_parse_pr,
+        mock_close_pr,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that NEW change proceeds without requiring --force."""
+        mock_check_status.return_value = "NEW"
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_pr.return_value = ("owner", "repo", 123)
+        mock_close_pr.return_value = None
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should not raise an error even without force
+        _process_close_gerrit_change(
+            mock_inputs,
+            mock_github_context,
+            gerrit_url,
+            force=False,
+        )
+
+        # Verify PR closure was attempted
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.cli.close_pr_with_status")
+    @patch("github2gerrit.cli.parse_pr_url")
+    @patch("github2gerrit.cli.extract_pr_url_from_gerrit_change")
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_unknown_status_proceeds_without_force(
+        self,
+        mock_check_status,
+        mock_extract_pr,
+        mock_parse_pr,
+        mock_close_pr,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that UNKNOWN status proceeds without requiring --force."""
+        mock_check_status.return_value = "UNKNOWN"
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_pr.return_value = ("owner", "repo", 123)
+        mock_close_pr.return_value = None
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should not raise an error even without force
+        _process_close_gerrit_change(
+            mock_inputs,
+            mock_github_context,
+            gerrit_url,
+            force=False,
+        )
+
+        # Verify PR closure was attempted
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.cli.extract_pr_url_from_gerrit_change")
+    @patch("github2gerrit.cli.check_gerrit_change_status")
+    def test_merged_change_no_pr_url_returns_early(
+        self,
+        mock_check_status,
+        mock_extract_pr,
+        mock_inputs,
+        mock_github_context,
+    ):
+        """Test that function returns early when no PR URL is found, even with force."""
+        mock_check_status.return_value = "MERGED"
+        mock_extract_pr.return_value = None  # No PR URL found
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should not raise an error but should return early
+        _process_close_gerrit_change(
+            mock_inputs,
+            mock_github_context,
+            gerrit_url,
+            force=True,
+        )
+
+        # No further processing should occur
+        mock_extract_pr.assert_called_once()

--- a/tests/test_gerrit_change_status_checks.py
+++ b/tests/test_gerrit_change_status_checks.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Tests for Gerrit change status verification and force flag behavior.
+
+Verifies that:
+1. Gerrit change status can be extracted from URLs
+2. Status checking works correctly (MERGED, ABANDONED, NEW, UNKNOWN)
+3. Force flag overrides status checks appropriately
+4. PR closure behavior respects or ignores status based on context
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from github2gerrit.gerrit_pr_closer import check_gerrit_change_status
+from github2gerrit.gerrit_pr_closer import (
+    close_github_pr_for_merged_gerrit_change,
+)
+from github2gerrit.gerrit_pr_closer import extract_change_number_from_url
+
+
+class TestExtractChangeNumberFromUrl:
+    """Tests for extracting change numbers from Gerrit URLs."""
+
+    def test_standard_gerrit_url(self):
+        """Test extraction from standard Gerrit URL format."""
+        url = "https://gerrit.example.org/c/project/+/12345"
+        result = extract_change_number_from_url(url)
+        assert result == ("gerrit.example.org", "12345")
+
+    def test_gerrit_url_with_subpath(self):
+        """Test extraction from Gerrit URL with subpath (e.g., /infra/)."""
+        url = "https://gerrit.linuxfoundation.org/infra/c/releng/lftools/+/123"
+        result = extract_change_number_from_url(url)
+        assert result == ("gerrit.linuxfoundation.org", "123")
+
+    def test_gerrit_url_with_nested_project(self):
+        """Test extraction from URL with deeply nested project path."""
+        url = "https://gerrit.example.org/c/some/nested/project/+/99999"
+        result = extract_change_number_from_url(url)
+        assert result == ("gerrit.example.org", "99999")
+
+    def test_invalid_url_returns_none(self):
+        """Test that invalid URLs return None."""
+        url = "https://github.com/owner/repo/pull/123"
+        result = extract_change_number_from_url(url)
+        assert result is None
+
+    def test_malformed_url_returns_none(self):
+        """Test that malformed Gerrit URLs return None."""
+        url = "https://gerrit.example.org/invalid/format"
+        result = extract_change_number_from_url(url)
+        assert result is None
+
+
+class TestCheckGerritChangeStatus:
+    """Tests for checking Gerrit change status via REST API."""
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client_for_host")
+    def test_merged_change_status(self, mock_build_client):
+        """Test detection of MERGED change status."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"status": "MERGED"}
+        mock_build_client.return_value = mock_client
+
+        url = "https://gerrit.example.org/c/project/+/12345"
+        status = check_gerrit_change_status(url)
+
+        assert status == "MERGED"
+        mock_client.get.assert_called_once_with("/changes/12345")
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client_for_host")
+    def test_abandoned_change_status(self, mock_build_client):
+        """Test detection of ABANDONED change status."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"status": "ABANDONED"}
+        mock_build_client.return_value = mock_client
+
+        url = "https://gerrit.example.org/c/project/+/67890"
+        status = check_gerrit_change_status(url)
+
+        assert status == "ABANDONED"
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client_for_host")
+    def test_new_change_status(self, mock_build_client):
+        """Test detection of NEW (open) change status."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"status": "NEW"}
+        mock_build_client.return_value = mock_client
+
+        url = "https://gerrit.example.org/c/project/+/11111"
+        status = check_gerrit_change_status(url)
+
+        assert status == "NEW"
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client_for_host")
+    def test_api_failure_returns_unknown(self, mock_build_client):
+        """Test that API failures return UNKNOWN status."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("API error")
+        mock_build_client.return_value = mock_client
+
+        url = "https://gerrit.example.org/c/project/+/12345"
+        status = check_gerrit_change_status(url)
+
+        assert status == "UNKNOWN"
+
+    def test_invalid_url_returns_unknown(self):
+        """Test that invalid URLs return UNKNOWN status."""
+        url = "https://invalid-url"
+        status = check_gerrit_change_status(url)
+
+        assert status == "UNKNOWN"
+
+
+class TestForceFlag:
+    """Tests for force flag behavior in PR closure."""
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    @patch("github2gerrit.gerrit_pr_closer.create_pr_comment")
+    def test_abandoned_change_without_close_merged_prs_adds_comment(
+        self,
+        mock_create_comment,
+        mock_extract_info,
+        mock_extract_pr,
+        mock_check_status,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that abandoned changes add comment but don't close PR when close_merged_prs=False."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_check_status.return_value = "ABANDONED"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # Mock PR info extraction
+        mock_extract_info.return_value = {
+            "Repository": "owner/repo",
+            "PR Number": 123,
+            "Title": "Test PR",
+            "Author": "bot",
+            "Base Branch": "main",
+            "SHA": "abc123",
+            "URL": "https://github.com/owner/repo/pull/123",
+        }
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should add comment but not close PR
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123de",
+            gerrit_change_url=gerrit_url,
+            close_merged_prs=False,
+        )
+
+        # Should not close PR, only add comment
+        mock_close_pr.assert_not_called()
+        mock_create_comment.assert_called_once()
+        assert result is True
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    def test_abandoned_change_with_force_closes_pr(
+        self,
+        mock_extract_info,
+        mock_extract_pr,
+        mock_check_status,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that force flag allows closing PR for abandoned changes."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_check_status.return_value = "ABANDONED"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # Mock PR info extraction
+        mock_extract_info.return_value = {
+            "Repository": "owner/repo",
+            "PR Number": 123,
+            "Title": "Test PR",
+            "Author": "bot",
+            "Base Branch": "main",
+            "SHA": "abc123",
+            "URL": "https://github.com/owner/repo/pull/123",
+        }
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should succeed regardless (push event context)
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123de",
+            gerrit_change_url=gerrit_url,
+        )
+
+        assert result is True
+        # Should attempt to close PR
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    def test_merged_change_closes_pr_without_force(
+        self,
+        mock_extract_info,
+        mock_extract_pr,
+        mock_check_status,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that merged changes close PRs without needing force flag."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_check_status.return_value = "MERGED"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # Mock PR info extraction
+        mock_extract_info.return_value = {
+            "Repository": "owner/repo",
+            "PR Number": 123,
+            "Title": "Test PR",
+            "Author": "bot",
+            "Base Branch": "main",
+            "SHA": "abc123",
+            "URL": "https://github.com/owner/repo/pull/123",
+        }
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should succeed (push event context)
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123de",
+            gerrit_change_url=gerrit_url,
+        )
+
+        assert result is True
+        mock_check_status.assert_called_once_with(gerrit_url)
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    def test_no_gerrit_url_skips_status_check(
+        self,
+        mock_extract_pr,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that status check is skipped when no Gerrit URL provided."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # No gerrit_change_url provided
+        with patch(
+            "github2gerrit.gerrit_pr_closer.extract_pr_info_for_display"
+        ) as mock_extract_info:
+            mock_extract_info.return_value = {
+                "Repository": "owner/repo",
+                "PR Number": 123,
+                "Title": "Test PR",
+                "Author": "bot",
+                "Base Branch": "main",
+                "SHA": "abc123",
+                "URL": "https://github.com/owner/repo/pull/123",
+            }
+
+            result = close_github_pr_for_merged_gerrit_change(
+                "abc123de",
+                gerrit_change_url=None,  # No URL provided
+            )
+
+        # Should succeed (status check skipped)
+        assert result is True
+        mock_close_pr.assert_called_once()
+
+
+class TestContextAwareBehavior:
+    """Tests for context-aware PR closure behavior."""
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    def test_new_change_warns_but_proceeds(
+        self,
+        mock_extract_info,
+        mock_extract_pr,
+        mock_check_status,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that NEW changes generate warning but still close PR."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_check_status.return_value = "NEW"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # Mock PR info extraction
+        mock_extract_info.return_value = {
+            "Repository": "owner/repo",
+            "PR Number": 123,
+            "Title": "Test PR",
+            "Author": "bot",
+            "Base Branch": "main",
+            "SHA": "abc123",
+            "URL": "https://github.com/owner/repo/pull/123",
+        }
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should proceed despite NEW status (push event context)
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123de",
+            gerrit_change_url=gerrit_url,
+        )
+
+        assert result is True
+        mock_close_pr.assert_called_once()
+
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    def test_unknown_status_warns_but_proceeds(
+        self,
+        mock_extract_info,
+        mock_extract_pr,
+        mock_check_status,
+        mock_close_pr,
+        mock_get_pull,
+        mock_build_client,
+    ):
+        """Test that UNKNOWN status generates warning but still closes PR."""
+        # Setup mocks
+        mock_extract_pr.return_value = "https://github.com/owner/repo/pull/123"
+        mock_check_status.return_value = "UNKNOWN"
+
+        # Mock GitHub API objects
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_build_client.return_value.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        # Mock PR info extraction
+        mock_extract_info.return_value = {
+            "Repository": "owner/repo",
+            "PR Number": 123,
+            "Title": "Test PR",
+            "Author": "bot",
+            "Base Branch": "main",
+            "SHA": "abc123",
+            "URL": "https://github.com/owner/repo/pull/123",
+        }
+
+        gerrit_url = "https://gerrit.example.org/c/project/+/12345"
+
+        # Should proceed despite UNKNOWN status (push event context)
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123de",
+            gerrit_change_url=gerrit_url,
+        )
+
+        assert result is True
+        mock_close_pr.assert_called_once()

--- a/tests/test_gerrit_pr_closer.py
+++ b/tests/test_gerrit_pr_closer.py
@@ -1,0 +1,697 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Tests for the gerrit_pr_closer module.
+
+Tests the functionality of closing GitHub PRs when Gerrit changes are merged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from github2gerrit.gerrit_pr_closer import _build_closure_comment
+from github2gerrit.gerrit_pr_closer import (
+    close_github_pr_for_merged_gerrit_change,
+)
+from github2gerrit.gerrit_pr_closer import extract_pr_info_for_display
+from github2gerrit.gerrit_pr_closer import extract_pr_url_from_commit
+from github2gerrit.gerrit_pr_closer import parse_pr_url
+from github2gerrit.gerrit_pr_closer import process_recent_commits_for_pr_closure
+
+
+class TestExtractPrUrlFromCommit:
+    """Tests for extract_pr_url_from_commit function."""
+
+    def test_extracts_pr_url_from_commit_with_trailer(self):
+        """Test extracting PR URL from a commit with GitHub-PR trailer."""
+        commit_message = """Fix critical bug
+
+This commit fixes a critical bug in the parser.
+
+Change-Id: I1234567890abcdef1234567890abcdef12345678
+GitHub-PR: https://github.com/owner/repo/pull/123
+GitHub-Hash: abc123
+Signed-off-by: Developer <dev@example.com>"""
+
+        with patch("github2gerrit.gerrit_pr_closer.git_show") as mock_git_show:
+            mock_git_show.return_value = commit_message
+
+            result = extract_pr_url_from_commit("abc123def456")
+
+            assert result == "https://github.com/owner/repo/pull/123"
+            mock_git_show.assert_called_once_with("abc123def456", fmt="%B")
+
+    def test_returns_none_when_no_trailer(self):
+        """Test returns None when commit has no GitHub-PR trailer."""
+        commit_message = """Regular commit
+
+Just a regular commit without any trailers.
+"""
+
+        with patch("github2gerrit.gerrit_pr_closer.git_show") as mock_git_show:
+            mock_git_show.return_value = commit_message
+
+            result = extract_pr_url_from_commit("xyz789")
+
+            assert result is None
+
+    def test_returns_last_trailer_when_multiple(self):
+        """Test returns the last GitHub-PR trailer when multiple exist."""
+        commit_message = """Commit with multiple trailers
+
+Change-Id: I1234567890abcdef1234567890abcdef12345678
+GitHub-PR: https://github.com/owner/repo/pull/111
+GitHub-PR: https://github.com/owner/repo/pull/222
+Signed-off-by: Developer <dev@example.com>"""
+
+        with patch("github2gerrit.gerrit_pr_closer.git_show") as mock_git_show:
+            mock_git_show.return_value = commit_message
+
+            result = extract_pr_url_from_commit("commit123")
+
+            assert result == "https://github.com/owner/repo/pull/222"
+
+    def test_handles_git_show_error(self):
+        """Test gracefully handles git show errors."""
+        with patch("github2gerrit.gerrit_pr_closer.git_show") as mock_git_show:
+            mock_git_show.side_effect = Exception("Git error")
+
+            result = extract_pr_url_from_commit("badcommit")
+
+            assert result is None
+
+
+class TestParsePrUrl:
+    """Tests for parse_pr_url function."""
+
+    def test_parses_valid_pr_url(self):
+        """Test parsing a valid GitHub PR URL."""
+        url = "https://github.com/owner/repo/pull/123"
+
+        result = parse_pr_url(url)
+
+        assert result == ("owner", "repo", 123)
+
+    def test_parses_http_url(self):
+        """Test parsing HTTP (not HTTPS) URL."""
+        url = "http://github.com/myorg/myrepo/pull/456"
+
+        result = parse_pr_url(url)
+
+        assert result == ("myorg", "myrepo", 456)
+
+    def test_returns_none_for_invalid_url(self):
+        """Test returns None for invalid URL format."""
+        invalid_urls = [
+            "not-a-url",
+            "https://gitlab.com/owner/repo/pull/123",
+            "https://github.com/owner/repo/issues/123",
+            "https://github.com/owner/repo",
+            "github.com/owner/repo/pull/123",
+        ]
+
+        for url in invalid_urls:
+            result = parse_pr_url(url)
+            assert result is None, f"Expected None for {url}"
+
+    def test_handles_numeric_pr_numbers(self):
+        """Test correctly parses PR number as integer."""
+        url = "https://github.com/test/test/pull/99999"
+
+        result = parse_pr_url(url)
+
+        assert result == ("test", "test", 99999)
+        assert isinstance(result[2], int)
+
+
+class TestExtractPrInfoForDisplay:
+    """Tests for extract_pr_info_for_display function."""
+
+    def test_extracts_complete_pr_info(self):
+        """Test extracting complete PR information."""
+        mock_pr = MagicMock()
+        mock_pr.title = "Test PR Title"
+        mock_pr.user.login = "testuser"
+        mock_pr.base.ref = "main"
+        mock_pr.head.sha = "abc123def456"
+        mock_pr.get_files.return_value = [MagicMock(), MagicMock()]  # 2 files
+
+        result = extract_pr_info_for_display(
+            mock_pr,
+            owner="owner",
+            repo="repo",
+            pr_number=42,
+        )
+
+        assert result["Repository"] == "owner/repo"
+        assert result["PR Number"] == 42
+        assert result["Title"] == "Test PR Title"
+        assert result["Author"] == "testuser"
+        assert result["Base Branch"] == "main"
+        assert result["SHA"] == "abc123def456"
+        assert result["URL"] == "https://github.com/owner/repo/pull/42"
+        assert result["Files Changed"] == 2
+
+    def test_handles_missing_user(self):
+        """Test handles PR with missing user information."""
+        mock_pr = MagicMock()
+        mock_pr.title = "Test PR"
+        mock_pr.user = None
+        mock_pr.base.ref = "main"
+        mock_pr.head.sha = "abc123"
+
+        result = extract_pr_info_for_display(mock_pr, "owner", "repo", 1)
+
+        assert result["Author"] == "Unknown"
+
+    def test_handles_files_error(self):
+        """Test handles error when fetching file count."""
+        mock_pr = MagicMock()
+        mock_pr.title = "Test PR"
+        mock_pr.user.login = "testuser"
+        mock_pr.base.ref = "main"
+        mock_pr.head.sha = "abc123"
+        mock_pr.get_files.side_effect = Exception("API error")
+
+        result = extract_pr_info_for_display(mock_pr, "owner", "repo", 1)
+
+        assert result["Files Changed"] == "unknown"
+
+
+class TestBuildClosureComment:
+    """Tests for _build_closure_comment function."""
+
+    def test_builds_comment_with_gerrit_url(self):
+        """Test builds comment with Gerrit change URL."""
+        gerrit_url = "https://gerrit.example.com/c/project/+/12345"
+
+        result = _build_closure_comment(gerrit_url)
+
+        assert "**Automated PR Closure**" in result
+        assert "merged" in result.lower()
+        assert gerrit_url in result
+        assert "GitHub2Gerrit" in result
+
+    def test_builds_comment_without_gerrit_url(self):
+        """Test builds comment without Gerrit change URL."""
+        result = _build_closure_comment(None)
+
+        assert "**Automated PR Closure**" in result
+        assert "merged" in result.lower()
+        assert "https://" not in result  # No specific URL
+        assert "GitHub2Gerrit" in result
+
+
+class TestCloseGithubPrForMergedGerritChange:
+    """Tests for close_github_pr_for_merged_gerrit_change function."""
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    @patch("github2gerrit.gerrit_pr_closer.display_pr_info")
+    def test_closes_pr_successfully(
+        self,
+        mock_display,
+        mock_extract_info,
+        mock_close,
+        mock_get_pull,
+        mock_build_client,
+        mock_parse_url,
+        mock_extract_url,
+    ):
+        """Test successfully closing a GitHub PR."""
+        # Setup mocks
+        mock_extract_url.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_url.return_value = ("owner", "repo", 123)
+
+        mock_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+
+        mock_build_client.return_value = mock_client
+        mock_client.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+        mock_extract_info.return_value = {"PR Number": 123}
+
+        # Execute
+        result = close_github_pr_for_merged_gerrit_change("abc123")
+
+        # Verify
+        assert result is True
+        mock_extract_url.assert_called_once_with("abc123")
+        mock_parse_url.assert_called_once_with(
+            "https://github.com/owner/repo/pull/123"
+        )
+        mock_client.get_repo.assert_called_once_with("owner/repo")
+        mock_get_pull.assert_called_once_with(mock_repo, 123)
+        mock_close.assert_called_once()
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    def test_returns_false_when_no_pr_url(self, mock_extract_url):
+        """Test returns False when commit has no PR URL."""
+        mock_extract_url.return_value = None
+
+        result = close_github_pr_for_merged_gerrit_change("commit123")
+
+        assert result is False
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    def test_returns_false_when_invalid_pr_url(
+        self, mock_parse_url, mock_extract_url
+    ):
+        """Test returns False when PR URL is invalid."""
+        mock_extract_url.return_value = "invalid-url"
+        mock_parse_url.return_value = None
+
+        result = close_github_pr_for_merged_gerrit_change("commit123")
+
+        assert result is False
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    @patch("github2gerrit.gerrit_pr_closer.display_pr_info")
+    def test_returns_false_when_pr_already_closed(
+        self,
+        mock_display,
+        mock_extract_info,
+        mock_get_pull,
+        mock_build_client,
+        mock_parse_url,
+        mock_extract_url,
+    ):
+        """Test returns False when PR already closed (non-fatal)."""
+        mock_extract_url.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_url.return_value = ("owner", "repo", 123)
+
+        mock_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "closed"  # Already closed
+
+        mock_build_client.return_value = mock_client
+        mock_client.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+
+        result = close_github_pr_for_merged_gerrit_change("abc123")
+
+        assert result is False
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    def test_returns_false_when_pr_not_found(
+        self,
+        mock_get_pull,
+        mock_build_client,
+        mock_parse_url,
+        mock_extract_url,
+    ):
+        """Test returns False when PR not found (404) - non-fatal."""
+        mock_extract_url.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_url.return_value = ("owner", "repo", 123)
+
+        mock_client = MagicMock()
+        mock_repo = MagicMock()
+
+        mock_build_client.return_value = mock_client
+        mock_client.get_repo.return_value = mock_repo
+
+        # Simulate 404 error when fetching PR
+        mock_get_pull.side_effect = Exception("404 Not Found")
+
+        # Should return False without raising exception
+        result = close_github_pr_for_merged_gerrit_change("abc123")
+
+        assert result is False
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    def test_returns_false_on_api_error(
+        self,
+        mock_get_pull,
+        mock_build_client,
+        mock_parse_url,
+        mock_extract_url,
+    ):
+        """Test returns False on GitHub API error - non-fatal."""
+        mock_extract_url.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_url.return_value = ("owner", "repo", 123)
+
+        mock_client = MagicMock()
+        mock_repo = MagicMock()
+
+        mock_build_client.return_value = mock_client
+        mock_client.get_repo.return_value = mock_repo
+
+        # Simulate API error
+        mock_get_pull.side_effect = Exception("API rate limit exceeded")
+
+        # Should return False without raising exception
+        result = close_github_pr_for_merged_gerrit_change("abc123")
+
+        assert result is False
+
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.get_pull")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_info_for_display")
+    @patch("github2gerrit.gerrit_pr_closer.display_pr_info")
+    def test_dry_run_mode(
+        self,
+        mock_display,
+        mock_extract_info,
+        mock_get_pull,
+        mock_build_client,
+        mock_parse_url,
+        mock_extract_url,
+    ):
+        """Test dry-run mode doesn't actually close PR."""
+        mock_extract_url.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse_url.return_value = ("owner", "repo", 123)
+
+        mock_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+
+        mock_build_client.return_value = mock_client
+        mock_client.get_repo.return_value = mock_repo
+        mock_get_pull.return_value = mock_pr
+        mock_extract_info.return_value = {"PR Number": 123}
+
+        with patch("github2gerrit.gerrit_pr_closer.close_pr") as mock_close:
+            result = close_github_pr_for_merged_gerrit_change(
+                "abc123", dry_run=True
+            )
+
+            assert result is True
+            mock_close.assert_not_called()  # Should not close in dry-run
+
+
+class TestProcessRecentCommitsForPrClosure:
+    """Tests for process_recent_commits_for_pr_closure function."""
+
+    @patch(
+        "github2gerrit.gerrit_pr_closer.close_github_pr_for_merged_gerrit_change"
+    )
+    def test_processes_multiple_commits(self, mock_close):
+        """Test processing multiple commits."""
+        mock_close.side_effect = [True, False, True]  # Close 2 out of 3
+
+        commits = ["commit1", "commit2", "commit3"]
+        result = process_recent_commits_for_pr_closure(commits)
+
+        assert result == 2
+        assert mock_close.call_count == 3
+
+    @patch(
+        "github2gerrit.gerrit_pr_closer.close_github_pr_for_merged_gerrit_change"
+    )
+    def test_returns_zero_for_empty_list(self, mock_close):
+        """Test returns 0 when no commits provided."""
+        result = process_recent_commits_for_pr_closure([])
+
+        assert result == 0
+        mock_close.assert_not_called()
+
+    @patch(
+        "github2gerrit.gerrit_pr_closer.close_github_pr_for_merged_gerrit_change"
+    )
+    def test_continues_on_error(self, mock_close):
+        """Test continues processing commits even when one fails."""
+        # Since the function is now non-fatal, it returns False on errors
+        mock_close.side_effect = [
+            True,
+            False,  # Returns False on error (non-fatal)
+            True,
+        ]
+
+        commits = ["commit1", "commit2", "commit3"]
+        result = process_recent_commits_for_pr_closure(commits)
+
+        assert result == 2  # Should have closed 2
+        assert mock_close.call_count == 3  # Should have tried all 3
+
+    @patch(
+        "github2gerrit.gerrit_pr_closer.close_github_pr_for_merged_gerrit_change"
+    )
+    def test_dry_run_mode_propagates(self, mock_close):
+        """Test dry-run mode propagates to individual close calls."""
+        mock_close.return_value = True
+
+        commits = ["commit1", "commit2"]
+        process_recent_commits_for_pr_closure(commits, dry_run=True)
+
+        # Verify dry_run=True passed to each call
+        for call_args in mock_close.call_args_list:
+            assert call_args[1]["dry_run"] is True
+
+    @patch(
+        "github2gerrit.gerrit_pr_closer.close_github_pr_for_merged_gerrit_change"
+    )
+    def test_no_exceptions_on_failures(self, mock_close):
+        """Test that failures don't raise exceptions (non-fatal behavior)."""
+        # Simulate various failure scenarios by returning False
+        mock_close.side_effect = [False, False, False]
+
+        commits = ["commit1", "commit2", "commit3"]
+
+        # Should not raise any exceptions
+        result = process_recent_commits_for_pr_closure(commits)
+
+        # All failed, so closed_count should be 0
+        assert result == 0
+        assert mock_close.call_count == 3
+
+
+class TestAbandonedChangeHandling:
+    """Tests for handling abandoned Gerrit changes."""
+
+    def test_build_abandoned_comment_with_url(self):
+        """Test building abandoned comment with Gerrit URL."""
+        from github2gerrit.gerrit_pr_closer import _build_abandoned_comment
+
+        url = "https://gerrit.example.org/c/project/+/12345"
+        comment = _build_abandoned_comment(url)
+
+        assert "Gerrit Change Abandoned" in comment
+        assert "🏳️" in comment
+        assert "abandoned" in comment
+        assert url in comment
+        assert "CLOSE_MERGED_PRS" in comment
+
+    def test_build_abandoned_comment_without_url(self):
+        """Test building abandoned comment without Gerrit URL."""
+        from github2gerrit.gerrit_pr_closer import _build_abandoned_comment
+
+        comment = _build_abandoned_comment(None)
+
+        assert "Gerrit Change Abandoned" in comment
+        assert "🏳️" in comment
+        assert "abandoned" in comment
+        assert "CLOSE_MERGED_PRS" in comment
+
+    def test_build_abandoned_notification_comment_with_url(self):
+        """Test building abandoned notification comment with Gerrit URL."""
+        from github2gerrit.gerrit_pr_closer import (
+            _build_abandoned_notification_comment,
+        )
+
+        url = "https://gerrit.example.org/c/project/+/12345"
+        comment = _build_abandoned_notification_comment(url)
+
+        assert "Gerrit Change Abandoned" in comment
+        assert "🏳️" in comment
+        assert "abandoned" in comment
+        assert url in comment
+        assert "remains open" in comment
+        assert "CLOSE_MERGED_PRS" in comment
+        assert "disabled" in comment
+
+    def test_build_abandoned_notification_comment_without_url(self):
+        """Test building abandoned notification comment without Gerrit URL."""
+        from github2gerrit.gerrit_pr_closer import (
+            _build_abandoned_notification_comment,
+        )
+
+        comment = _build_abandoned_notification_comment(None)
+
+        assert "Gerrit Change Abandoned" in comment
+        assert "🏳️" in comment
+        assert "abandoned" in comment
+        assert "remains open" in comment
+
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    def test_close_pr_when_abandoned_and_close_merged_prs_true(
+        self,
+        mock_close_pr,
+        mock_build_client,
+        mock_parse,
+        mock_extract,
+        mock_check_status,
+    ):
+        """Test PR is closed when change is abandoned and close_merged_prs=True."""
+        # Setup mocks
+        mock_check_status.return_value = "ABANDONED"
+        mock_extract.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse.return_value = ("owner", "repo", 123)
+
+        # Mock GitHub API
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_pr.number = 123
+        mock_repo = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_client = MagicMock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_build_client.return_value = mock_client
+
+        # Call function with close_merged_prs=True (default)
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123",
+            gerrit_change_url="https://gerrit.example.org/c/project/+/12345",
+            close_merged_prs=True,
+        )
+
+        assert result is True
+        mock_close_pr.assert_called_once()
+        # Verify the comment contains abandoned message
+        call_args = mock_close_pr.call_args
+        comment = call_args[1]["comment"]
+        assert "abandoned" in comment.lower()
+        assert "🏳️" in comment
+
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.create_pr_comment")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    def test_comment_only_when_abandoned_and_close_merged_prs_false(
+        self,
+        mock_close_pr,
+        mock_create_comment,
+        mock_build_client,
+        mock_parse,
+        mock_extract,
+        mock_check_status,
+    ):
+        """Test only comment added when change is abandoned and close_merged_prs=False."""
+        # Setup mocks
+        mock_check_status.return_value = "ABANDONED"
+        mock_extract.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse.return_value = ("owner", "repo", 123)
+
+        # Mock GitHub API
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_pr.number = 123
+        mock_repo = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_client = MagicMock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_build_client.return_value = mock_client
+
+        # Call function with close_merged_prs=False
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123",
+            gerrit_change_url="https://gerrit.example.org/c/project/+/12345",
+            close_merged_prs=False,
+        )
+
+        assert result is True
+        # PR should NOT be closed
+        mock_close_pr.assert_not_called()
+        # Comment should be added
+        mock_create_comment.assert_called_once()
+        # Verify the comment contains abandoned notification
+        call_args = mock_create_comment.call_args
+        comment = call_args[0][1]
+        assert "abandoned" in comment.lower()
+        assert "remains open" in comment.lower()
+        assert "🏳️" in comment
+
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    @patch("github2gerrit.gerrit_pr_closer.parse_pr_url")
+    @patch("github2gerrit.gerrit_pr_closer.build_client")
+    @patch("github2gerrit.gerrit_pr_closer.close_pr")
+    def test_close_pr_when_merged_and_close_merged_prs_true(
+        self,
+        mock_close_pr,
+        mock_build_client,
+        mock_parse,
+        mock_extract,
+        mock_check_status,
+    ):
+        """Test PR is closed when change is merged and close_merged_prs=True."""
+        # Setup mocks
+        mock_check_status.return_value = "MERGED"
+        mock_extract.return_value = "https://github.com/owner/repo/pull/123"
+        mock_parse.return_value = ("owner", "repo", 123)
+
+        # Mock GitHub API
+        mock_pr = MagicMock()
+        mock_pr.state = "open"
+        mock_pr.number = 123
+        mock_repo = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_client = MagicMock()
+        mock_client.get_repo.return_value = mock_repo
+        mock_build_client.return_value = mock_client
+
+        # Call function with close_merged_prs=True
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123",
+            gerrit_change_url="https://gerrit.example.org/c/project/+/12345",
+            close_merged_prs=True,
+        )
+
+        assert result is True
+        mock_close_pr.assert_called_once()
+        # Verify the comment contains merged message (not abandoned)
+        call_args = mock_close_pr.call_args
+        comment = call_args[1]["comment"]
+        assert "merged" in comment.lower()
+        assert "abandoned" not in comment.lower()
+
+    @patch("github2gerrit.gerrit_pr_closer.check_gerrit_change_status")
+    @patch("github2gerrit.gerrit_pr_closer.extract_pr_url_from_commit")
+    def test_no_action_when_merged_and_close_merged_prs_false(
+        self,
+        mock_extract,
+        mock_check_status,
+    ):
+        """Test no action taken when change is merged and close_merged_prs=False."""
+        # Setup mocks
+        mock_check_status.return_value = "MERGED"
+        mock_extract.return_value = "https://github.com/owner/repo/pull/123"
+
+        # Call function with close_merged_prs=False
+        result = close_github_pr_for_merged_gerrit_change(
+            "abc123",
+            gerrit_change_url="https://gerrit.example.org/c/project/+/12345",
+            close_merged_prs=False,
+        )
+
+        # Should return False (no action taken)
+        assert result is False

--- a/tests/test_ghe_and_gitreview_args.py
+++ b/tests/test_ghe_and_gitreview_args.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import pytest
 
+from github2gerrit.cli import GitHubPRTarget
+from github2gerrit.cli import GitHubRepoTarget
 from github2gerrit.cli import _parse_github_target
 from github2gerrit.core import GerritInfo
 from github2gerrit.core import Orchestrator
@@ -26,15 +28,21 @@ def test_ghe_url_parsing_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Default: reject GHE (env unset -> default False)
     monkeypatch.delenv("ALLOW_GHE_URLS", raising=False)
-    assert _parse_github_target(ghe_url) == (None, None, None)
+    assert _parse_github_target(ghe_url) == GitHubRepoTarget(
+        owner=None, repo=None
+    )
 
     # Enable GHE: accept non-github.com hosts
     monkeypatch.setenv("ALLOW_GHE_URLS", "true")
-    assert _parse_github_target(ghe_url) == ("org", "repo", 123)
+    assert _parse_github_target(ghe_url) == GitHubPRTarget(
+        owner="org", repo="repo", pr_number=123
+    )
 
     # With ALLOW_GHE_URLS=false, standard github.com URL still parses
     monkeypatch.setenv("ALLOW_GHE_URLS", "false")
-    assert _parse_github_target(gh_url) == ("org", "repo", 456)
+    assert _parse_github_target(gh_url) == GitHubPRTarget(
+        owner="org", repo="repo", pr_number=456
+    )
 
 
 def test_git_review_args_include_branch_and_repeated_reviewer_flags(

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -17,6 +17,8 @@ else:
 
     parametrize = mark.parametrize
 
+from github2gerrit.cli import GitHubPRTarget
+from github2gerrit.cli import GitHubRepoTarget
 from github2gerrit.cli import _parse_github_target
 
 
@@ -26,49 +28,49 @@ from github2gerrit.cli import _parse_github_target
         # Standard PR URLs
         (
             "https://github.com/onap/portal-ng-bff/pull/33",
-            ("onap", "portal-ng-bff", 33),
+            GitHubPRTarget(owner="onap", repo="portal-ng-bff", pr_number=33),
         ),
         (
             "https://www.github.com/onap/portal-ng-bff/pull/33",
-            ("onap", "portal-ng-bff", 33),
+            GitHubPRTarget(owner="onap", repo="portal-ng-bff", pr_number=33),
         ),
         # Repo URL (no PR number)
         (
             "https://github.com/onap/portal-ng-bff",
-            ("onap", "portal-ng-bff", None),
+            GitHubRepoTarget(owner="onap", repo="portal-ng-bff"),
         ),
         # 'pulls' accepted as well
         (
             "https://github.com/onap/portal-ng-bff/pulls/33",
-            ("onap", "portal-ng-bff", 33),
+            GitHubPRTarget(owner="onap", repo="portal-ng-bff", pr_number=33),
         ),
         # Trailing slashes should be fine
         (
             "https://github.com/onap/portal-ng-bff/",
-            ("onap", "portal-ng-bff", None),
+            GitHubRepoTarget(owner="onap", repo="portal-ng-bff"),
         ),
         # Query string and fragment should be ignored by parsing
         (
             "https://github.com/onap/portal-ng-bff/pull/33?foo=bar#section",
-            ("onap", "portal-ng-bff", 33),
+            GitHubPRTarget(owner="onap", repo="portal-ng-bff", pr_number=33),
         ),
         # Non-integer PR number: pr component should become None
         (
             "https://github.com/onap/portal-ng-bff/pull/not-a-number",
-            ("onap", "portal-ng-bff", None),
+            GitHubRepoTarget(owner="onap", repo="portal-ng-bff"),
         ),
         # Non-GitHub domain: reject
         (
             "https://gitlab.com/onap/portal-ng-bff/pull/33",
-            (None, None, None),
+            GitHubRepoTarget(owner=None, repo=None),
         ),
         # Insufficient path parts: reject
-        ("https://github.com/onap", (None, None, None)),
-        ("https://github.com/", (None, None, None)),
-        ("https://github.com", (None, None, None)),
+        ("https://github.com/onap", GitHubRepoTarget(owner=None, repo=None)),
+        ("https://github.com/", GitHubRepoTarget(owner=None, repo=None)),
+        ("https://github.com", GitHubRepoTarget(owner=None, repo=None)),
     ],
 )
 def test_parse_github_target(
-    url: str, expected: tuple[object, object, object]
+    url: str, expected: GitHubPRTarget | GitHubRepoTarget
 ) -> None:
     assert _parse_github_target(url) == expected


### PR DESCRIPTION
- Add GitHub PR close handling after Gerrit change is merged
- Add CLI ability to accept Gerrit change as input, close PRs
- New --force flag will close GitHub PRs for Abandoned changes
- Add code to extract GitHub ORG from Gerrit change content
- Only display relevant output in GitHub2Gerrit Configuration
- Bypass uvx when testing/developing against branches in forks
- Improve isolation to address failing pre-commit pytest hook
- Add new automation_only input and CLI flag to reject user PRs