### PR TITLE
Fix: NACR-safe author handling for human PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1457,6 +1457,33 @@ requiring manual configuration per PR or user.
   - By default, PRs are **preserved** after submission (`PRESERVE_GITHUB_PRS=true`).
   - Set `PRESERVE_GITHUB_PRS=false` to close PRs after submission on `pull_request_target` events.
 
+### NACR-Safe Author Handling
+
+When submitting changes to Gerrit, the tool handles git authorship to ensure
+compatibility with Gerrit's Non-Author Code Review (NACR) policy:
+
+- **Bot PRs** (Dependabot, pre-commit-ci, renovate, etc.): The tool keeps the
+  original bot identity as the git author. Since bots never review their own
+  changes, NACR does not apply.
+- **Human PRs**: The tool assigns the GitHub2Gerrit bot identity
+  (e.g., `opendaylight.gh2gerrit`) as the git author and appends a
+  `Co-authored-by` trailer to the commit message, preserving attribution
+  to the original human author.
+
+This prevents the situation where a human PR author becomes the Gerrit change
+"owner" (Gerrit derives ownership from the git Author field), which would block
+them from approving their own change under NACR policy.
+
+Bot detection uses a three-level check:
+
+1. Exact match against a list of known automation accounts (e.g., `dependabot[bot]`,
+   `pre-commit-ci[bot]`, `renovate[bot]`, `github-actions[bot]`)
+2. GitHub `[bot]` suffix convention
+3. Word-boundary heuristic for bot-like usernames
+
+When the tool fails to determine the PR author (e.g., API failure), it
+conservatively treats the author as human to avoid NACR violations.
+
 ## Security notes
 
 - Do not hardcode secrets or keys. Provide the private key via the

--- a/src/github2gerrit/bot_detection.py
+++ b/src/github2gerrit/bot_detection.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""
+Bot author detection for GitHub PRs.
+
+Determines whether a PR was authored by a known automation bot (e.g.,
+Dependabot, pre-commit-ci, Renovate) vs. a human developer.
+
+This distinction is critical for Gerrit NACR (Non-Author Code Review):
+when G2G preserves a human developer as the git commit author, Gerrit
+treats that developer as the change owner, blocking them from
+self-approving their own G2G-submitted change.  For bot PRs this is
+not an issue because bots never review their own changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+
+__all__ = ["KNOWN_BOT_LOGINS", "is_bot_author"]
+
+log = logging.getLogger("github2gerrit.bot_detection")
+
+# GitHub login names for well-known automation bots.
+# Entries are compared case-insensitively.
+KNOWN_BOT_LOGINS: frozenset[str] = frozenset(
+    {
+        "dependabot[bot]",
+        "pre-commit-ci[bot]",
+        "renovate[bot]",
+        "github-actions[bot]",
+        "snyk-bot",
+        "mergify[bot]",
+        "greenkeeper[bot]",
+        "depfu[bot]",
+        "imgbot[bot]",
+        "allcontributors[bot]",
+        "codecov[bot]",
+        "stale[bot]",
+        "lgtm-com[bot]",
+        "sonarcloud[bot]",
+    }
+)
+
+# Pre-computed lowercase set for O(1) lookups in is_bot_author()
+_KNOWN_BOT_LOGINS_LOWER: frozenset[str] = frozenset(
+    b.lower() for b in KNOWN_BOT_LOGINS
+)
+
+# Pattern that catches any GitHub App bot login (ends with [bot])
+_BOT_SUFFIX_RE = re.compile(r"\[bot\]$", re.IGNORECASE)
+
+
+def is_bot_author(author_login: str | None) -> bool:
+    """Determine whether a GitHub PR author is an automation bot.
+
+    Detection strategy (any match → True):
+    1. Exact match against ``KNOWN_BOT_LOGINS`` (case-insensitive).
+    2. Login ends with ``[bot]`` (GitHub App convention).
+    3. Login contains ``bot`` as a distinct word boundary.
+
+    Args:
+        author_login: The GitHub ``user.login`` of the PR author.
+            May be empty/None, in which case the function returns False
+            (treat unknown authors conservatively as human).
+
+    Returns:
+        True if the author is a known bot, False otherwise.
+    """
+    if not author_login:
+        return False
+
+    login_lower = author_login.strip().lower()
+
+    # 1. Exact match against known bots
+    if login_lower in _KNOWN_BOT_LOGINS_LOWER:
+        log.debug("Bot detected (exact match): %s", author_login)
+        return True
+
+    # 2. GitHub App convention: login ends with [bot]
+    if _BOT_SUFFIX_RE.search(login_lower):
+        log.debug("Bot detected ([bot] suffix): %s", author_login)
+        return True
+
+    # 3. Heuristic: "bot" as word boundary (catches custom bots)
+    #    Exclude common false positives like "abbott", "robot" etc.
+    if re.search(r"(?<![a-z])bot(?![a-z])", login_lower):
+        log.debug("Bot detected (word-boundary heuristic): %s", author_login)
+        return True
+
+    log.debug("Author classified as human: %s", author_login)
+    return False

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -44,6 +44,7 @@ from typing import Any
 from urllib.request import Request
 from urllib.request import urlopen
 
+from .bot_detection import is_bot_author
 from .commit_normalization import normalize_commit_title
 from .gerrit_urls import create_gerrit_url_builder
 from .github_api import build_client
@@ -912,6 +913,7 @@ class Orchestrator:
         g2g_mode: str | None = None,
         g2g_topic: str | None = None,
         g2g_change_ids: list[str] | None = None,
+        extra_co_authored_by: str | None = None,
     ) -> str:
         """
         Build complete commit message with all trailers in proper order.
@@ -921,9 +923,10 @@ class Orchestrator:
         Trailer order:
         1. Issue-ID (if provided)
         2. Signed-off-by (preserved or added)
-        3. Change-ID (if provided or preserved)
-        4. GitHub-PR
-        5. GitHub-Hash
+        3. Co-authored-by (when NACR author swap is active)
+        4. Change-ID (if provided or preserved)
+        5. GitHub-PR
+        6. GitHub-Hash
 
         Args:
             base_message: The base commit message (subject + body)
@@ -936,6 +939,9 @@ class Orchestrator:
             g2g_mode: Mode for metadata block (squash/multi-commit)
             g2g_topic: Topic for metadata block
             g2g_change_ids: Change-IDs for metadata block
+            extra_co_authored_by: Optional Co-authored-by trailer to add
+                (used for NACR author swap — preserves human attribution
+                when bot is set as the git author)
 
         Returns:
             Complete commit message with all trailers properly ordered
@@ -1011,6 +1017,17 @@ class Orchestrator:
                 if sob_line not in seen_sob:
                     trailers_ordered.append(sob_line)
                     seen_sob.add(sob_line)
+
+        # 2b. Co-authored-by (NACR swap or preserved existing)
+        seen_coauth: set[str] = set()
+        if preserve_existing and "Co-authored-by" in existing_trailers:
+            for ca_val in existing_trailers["Co-authored-by"]:
+                ca_line = f"Co-authored-by: {ca_val}"
+                if ca_line not in seen_coauth:
+                    trailers_ordered.append(ca_line)
+                    seen_coauth.add(ca_line)
+        if extra_co_authored_by and extra_co_authored_by not in seen_coauth:
+            trailers_ordered.append(extra_co_authored_by)
 
         # 3. Change-ID
         if change_id:
@@ -3064,14 +3081,22 @@ class Orchestrator:
             create_branch=True,
         )
         change_ids: list[str] = []
+        # Fetch PR author login once for NACR-safe author resolution
+        pr_author_login = self._get_pr_author_login(gh)
         for idx, csha in enumerate(commit_list):
             run_cmd(["git", "checkout", tmp_branch], cwd=self.workspace)
             git_cherry_pick(csha, cwd=self.workspace)
-            # Preserve author of the original commit
-            author = run_cmd(
+            # Get original commit author
+            original_author = run_cmd(
                 ["git", "show", "-s", "--pretty=format:%an <%ae>", csha],
                 cwd=self.workspace,
             ).stdout.strip()
+            # NACR-safe: swap human authors to bot, keep bot authors as-is
+            author, co_authored_trailer = self._resolve_author_for_gerrit(
+                original_author,
+                pr_author_login,
+                inputs,
+            )
             git_commit_amend(
                 author=author, no_edit=True, signoff=True, cwd=self.workspace
             )
@@ -3111,6 +3136,7 @@ class Orchestrator:
                 g2g_mode="multi-commit",
                 g2g_topic=topic,
                 g2g_change_ids=reuse_change_ids if reuse_change_ids else None,
+                extra_co_authored_by=co_authored_trailer,
             )
 
             # Only amend if message changed
@@ -3482,20 +3508,31 @@ class Orchestrator:
         # Build base message with Signed-off-by
         base_msg = _compose_base_message(clean_lines, signed_off)
 
+        # Fetch PR author for NACR-safe resolution
+        pr_author_login = self._get_pr_author_login(gh)
+
         # Use centralized function to build complete message with all trailers
+        # (Co-authored-by is injected below after author resolution)
+        original_author = run_cmd(
+            ["git", "show", "-s", "--pretty=format:%an <%ae>", head_sha],
+            cwd=self.workspace,
+        ).stdout.strip()
+
+        # NACR-safe: swap human authors to bot, keep bot authors as-is
+        author, co_authored_trailer = self._resolve_author_for_gerrit(
+            original_author,
+            pr_author_login,
+            inputs,
+        )
+
         commit_msg = self._build_commit_message_with_trailers(
             base_message=base_msg,
             inputs=inputs,
             gh=gh,
             change_id=reuse_cid,
             preserve_existing=True,
+            extra_co_authored_by=co_authored_trailer,
         )
-
-        # Preserve primary author from the PR head commit
-        author = run_cmd(
-            ["git", "show", "-s", "--pretty=format:%an <%ae>", head_sha],
-            cwd=self.workspace,
-        ).stdout.strip()
 
         git_commit_new(
             message=commit_msg,
@@ -3664,12 +3701,29 @@ class Orchestrator:
 
         commit_message = "\n".join(new_message_parts).strip()
 
-        # Get current author
-        author = run_cmd(
+        # Get current author and resolve for NACR safety
+        original_author = run_cmd(
             ["git", "show", "-s", "--pretty=format:%an <%ae>", "HEAD"],
             cwd=self.workspace,
             env=self._ssh_env(),
         ).stdout.strip()
+        author, co_authored_trailer = self._resolve_author_for_gerrit(
+            original_author,
+            author_login,
+            inputs,
+        )
+
+        # Inject Co-authored-by trailer if NACR swap occurred
+        if co_authored_trailer:
+            # Insert before existing trailers
+            if existing_trailers:
+                # Find the blank line before trailers and insert after it
+                insert_idx = len(new_message_parts) - len(existing_trailers)
+                new_message_parts.insert(insert_idx, co_authored_trailer)
+            else:
+                new_message_parts.append("")
+                new_message_parts.append(co_authored_trailer)
+            commit_message = "\n".join(new_message_parts).strip()
 
         # Check if Signed-off-by exists
         has_signoff = any(
@@ -6083,6 +6137,89 @@ class Orchestrator:
             log.exception("Failed to gather debug context")
 
         log.error("=== End verbose merge failure analysis ===")
+
+    # -----------------------------------------------------------------
+    # NACR-safe author resolution
+    # -----------------------------------------------------------------
+    def _resolve_author_for_gerrit(
+        self,
+        original_author: str,
+        pr_author_login: str,
+        inputs: Inputs,
+    ) -> tuple[str, str | None]:
+        """Choose the git ``--author`` and optional Co-authored-by trailer.
+
+        When a *human* developer opens a GitHub PR and G2G pushes the
+        resulting commit to Gerrit, preserving the human as the git
+        author can trigger NACR (Non-Author Code-Review) restrictions,
+        preventing the developer from self-approving their own change.
+
+        For **bot** PRs (Dependabot, pre-commit-ci, etc.) we keep the
+        original author because bots never review their own changes and
+        maintainers need to see who actually produced the update.
+
+        Args:
+            original_author: ``Name <email>`` from ``git show --pretty``.
+            pr_author_login: GitHub ``user.login`` of the PR author.
+            inputs: Pipeline inputs (provides bot identity).
+
+        Returns:
+            A 2-tuple ``(author_for_commit, co_authored_by_trailer)``.
+            *co_authored_by_trailer* is ``None`` when no swap occurs.
+        """
+        if is_bot_author(pr_author_login):
+            log.debug(
+                "Bot PR author %r — preserving original author %s",
+                pr_author_login,
+                original_author,
+            )
+            return original_author, None
+
+        # Human PR — use the G2G bot identity as the commit author
+        # so the Gerrit change is "owned" by the bot, and the human
+        # can self-+2.
+        bot_name = inputs.gerrit_ssh_user_g2g or "github2gerrit-bot"
+        bot_email = (
+            inputs.gerrit_ssh_user_g2g_email or "github2gerrit@example.com"
+        )
+        bot_author = f"{bot_name} <{bot_email}>"
+
+        # Guard: if original_author already IS the bot (e.g. autosquash
+        # path where _prepare_squashed_commit already performed the swap),
+        # skip re-resolution to avoid a double-swap.
+        if original_author == bot_author:
+            log.debug(
+                "Author already set to bot %r — skipping duplicate NACR swap",
+                bot_author,
+            )
+            return original_author, None
+
+        co_authored_trailer = f"Co-authored-by: {original_author}"
+        log.info(
+            "NACR swap: human PR by %r — author set to bot identity",
+            pr_author_login,
+        )
+        log.debug("NACR trailer: %s", co_authored_trailer)
+        return bot_author, co_authored_trailer
+
+    def _get_pr_author_login(self, gh: GitHubContext) -> str:
+        """Fetch the GitHub login of the PR author.
+
+        Returns an empty string when the PR number is unknown or the API
+        call fails (conservative fallback: treat as human).
+        """
+        pr_num = gh.pr_number
+        if not pr_num:
+            return ""
+        try:
+            client = build_client()
+            repo = get_repo_from_env(client)
+            pr_obj = get_pull(repo, int(pr_num))
+            user = getattr(pr_obj, "user", None)
+            return getattr(user, "login", "") if user else ""
+        except Exception as exc:
+            log.debug("Failed to fetch PR author login: %s", exc)
+            return ""
 
     def _ensure_git_user_identity(self, inputs: Inputs) -> None:
         """Ensure git user identity is configured for merge operations."""

--- a/tests/test_bot_detection.py
+++ b/tests/test_bot_detection.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for bot author detection module.
+
+Validates the ``is_bot_author`` function that distinguishes between
+automation bots and human developers, which is critical for the
+NACR (Non-Author Code Review) author-swap logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from github2gerrit.bot_detection import KNOWN_BOT_LOGINS
+from github2gerrit.bot_detection import is_bot_author
+
+
+class TestKnownBotLogins:
+    """Verify known bot logins are detected correctly."""
+
+    @pytest.mark.parametrize(
+        "login",
+        sorted(KNOWN_BOT_LOGINS),
+        ids=sorted(KNOWN_BOT_LOGINS),
+    )
+    def test_all_known_bots_detected(self, login: str) -> None:
+        """Each entry in KNOWN_BOT_LOGINS must return True."""
+        assert is_bot_author(login) is True
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "Dependabot[bot]",
+            "DEPENDABOT[BOT]",
+            "Pre-Commit-Ci[Bot]",
+            "RENOVATE[BOT]",
+        ],
+    )
+    def test_known_bots_case_insensitive(self, login: str) -> None:
+        """Known bot detection must be case-insensitive."""
+        assert is_bot_author(login) is True
+
+
+class TestBotSuffixConvention:
+    """GitHub App bots use the ``[bot]`` suffix."""
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "custom-app[bot]",
+            "my-org-ci[bot]",
+            "lfreleng[bot]",
+            "some-NEW-tool[Bot]",
+            "UNKNOWN[BOT]",
+        ],
+    )
+    def test_unknown_bot_suffix_detected(self, login: str) -> None:
+        """Any login ending with [bot] should be detected as bot."""
+        assert is_bot_author(login) is True
+
+
+class TestWordBoundaryHeuristic:
+    """Heuristic catches custom bots with ``bot`` as a word boundary."""
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "my-bot",
+            "bot-runner",
+            "ci-bot-42",
+            "Bot",
+            "BOT",
+        ],
+    )
+    def test_word_boundary_bots_detected(self, login: str) -> None:
+        """Logins with 'bot' at a word boundary should be detected."""
+        assert is_bot_author(login) is True
+
+
+class TestFalsePositiveProtection:
+    """Ensure common human names are NOT misclassified as bots."""
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "abbott",
+            "robot",
+            "roboto",
+            "bottleneck",
+            "saboteur",
+            "turnbottom",
+        ],
+    )
+    def test_human_names_not_flagged(self, login: str) -> None:
+        """Words containing 'bot' as a substring must NOT match."""
+        assert is_bot_author(login) is False
+
+
+class TestHumanAuthors:
+    """Regular human GitHub logins."""
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "askb",
+            "octocat",
+            "johndoe",
+            "alice-smith",
+            "user_123",
+            "rvarga",
+        ],
+    )
+    def test_human_authors_not_flagged(self, login: str) -> None:
+        """Normal human logins must return False."""
+        assert is_bot_author(login) is False
+
+
+class TestEdgeCases:
+    """Edge cases: empty, None, whitespace."""
+
+    def test_empty_string_returns_false(self) -> None:
+        """Empty login → conservative human classification."""
+        assert is_bot_author("") is False
+
+    def test_none_returns_false(self) -> None:
+        """None login → conservative human classification."""
+        assert is_bot_author(None) is False
+
+    def test_whitespace_only_returns_false(self) -> None:
+        """Whitespace-only login → False."""
+        assert is_bot_author("   ") is False
+
+    def test_login_with_surrounding_whitespace(self) -> None:
+        """Leading/trailing whitespace should be stripped."""
+        assert is_bot_author("  dependabot[bot]  ") is True

--- a/tests/test_gerrit_change_id_footer.py
+++ b/tests/test_gerrit_change_id_footer.py
@@ -214,7 +214,7 @@ def test_apply_pr_title_body_preserves_change_id_footer(
     first_trailer_idx = min(
         i
         for i, ln in enumerate(lines)
-        if ln.startswith(("Signed-off-by:", "Change-Id:"))
+        if ln.startswith(("Co-authored-by:", "Signed-off-by:", "Change-Id:"))
     )
     assert first_trailer_idx >= 2, (
         "Expected trailers to be separated by a blank line from body"

--- a/tests/test_nacr_author_swap.py
+++ b/tests/test_nacr_author_swap.py
@@ -1,0 +1,377 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for NACR (Non-Author Code Review) author-swap logic.
+
+Validates the ``_resolve_author_for_gerrit`` and ``_get_pr_author_login``
+methods on ``Orchestrator``, as well as the Co-authored-by trailer
+injection in ``_build_commit_message_with_trailers``.
+
+The NACR fix ensures that when a *human* developer opens a GitHub PR,
+G2G swaps the commit author to the bot identity and preserves the
+original author via a ``Co-authored-by`` trailer.  For *bot* PRs the
+original author is preserved unchanged.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from github2gerrit.bot_detection import is_bot_author
+from github2gerrit.core import Orchestrator
+
+
+# ---------------------------------------------------------------------------
+# Helpers — lightweight stand-ins for Inputs / GitHubContext
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(
+    *,
+    gerrit_ssh_user_g2g: str = "opendaylight.gh2gerrit",
+    gerrit_ssh_user_g2g_email: str = "releng+odl-gh2gerrit@linuxfoundation.org",
+    issue_id: str = "",
+) -> SimpleNamespace:
+    """Minimal ``Inputs``-like object for testing."""
+    return SimpleNamespace(
+        gerrit_ssh_user_g2g=gerrit_ssh_user_g2g,
+        gerrit_ssh_user_g2g_email=gerrit_ssh_user_g2g_email,
+        issue_id=issue_id,
+    )
+
+
+def _make_gh(pr_number: str | None = "42") -> SimpleNamespace:
+    """Minimal ``GitHubContext``-like object for testing."""
+    return SimpleNamespace(
+        pr_number=pr_number,
+        server_url="https://github.com",
+        repository="opendaylight/mdsal",
+        head_sha="abc1234",
+    )
+
+
+def _make_mock_self() -> MagicMock:
+    """Create a MagicMock standing in for an Orchestrator instance.
+
+    Pre-configures ``_build_pr_metadata_trailers`` to return an empty
+    list so that ``_build_commit_message_with_trailers`` works without
+    needing a real GitHub context.
+    """
+    mock = MagicMock(spec=Orchestrator)
+    mock._build_pr_metadata_trailers.return_value = []
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# _resolve_author_for_gerrit
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAuthorForGerrit:
+    """Test author resolution for Gerrit submission."""
+
+    def test_bot_pr_preserves_original_author(self) -> None:
+        """Bot PRs keep original author; no Co-authored-by trailer."""
+        mock_self = _make_mock_self()
+
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="dependabot[bot] <dependabot@github.com>",
+            pr_author_login="dependabot[bot]",
+            inputs=_make_inputs(),
+        )
+
+        assert author == "dependabot[bot] <dependabot@github.com>"
+        assert trailer is None
+
+    def test_human_pr_swaps_to_bot_author(self) -> None:
+        """Human PRs use bot identity as author."""
+        mock_self = _make_mock_self()
+
+        author, _trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="Anil Belur <askb23@gmail.com>",
+            pr_author_login="askb",
+            inputs=_make_inputs(),
+        )
+
+        assert "opendaylight.gh2gerrit" in author
+        assert "releng+odl-gh2gerrit@linuxfoundation.org" in author
+
+    def test_human_pr_adds_co_authored_by_trailer(self) -> None:
+        """Human PRs get a Co-authored-by trailer for attribution."""
+        mock_self = _make_mock_self()
+
+        _, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="Robert Varga <rovarga@example.com>",
+            pr_author_login="rvarga",
+            inputs=_make_inputs(),
+        )
+
+        assert trailer is not None
+        assert trailer == "Co-authored-by: Robert Varga <rovarga@example.com>"
+
+    def test_empty_login_treated_as_human(self) -> None:
+        """Empty login (API failure) → conservative: treat as human → swap."""
+        mock_self = _make_mock_self()
+
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="Unknown Dev <dev@example.com>",
+            pr_author_login="",
+            inputs=_make_inputs(),
+        )
+
+        # Empty string → is_bot_author returns False → human path
+        assert "opendaylight.gh2gerrit" in author
+        assert trailer is not None
+        assert "Unknown Dev" in trailer
+
+    def test_custom_bot_identity(self) -> None:
+        """Non-default bot identity is used when configured."""
+        mock_self = _make_mock_self()
+
+        author, _ = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="Human <human@example.com>",
+            pr_author_login="human-dev",
+            inputs=_make_inputs(
+                gerrit_ssh_user_g2g="myorg-bot",
+                gerrit_ssh_user_g2g_email="bot@myorg.example",
+            ),
+        )
+
+        assert author == "myorg-bot <bot@myorg.example>"
+
+    @pytest.mark.parametrize(
+        "bot_login",
+        [
+            "dependabot[bot]",
+            "pre-commit-ci[bot]",
+            "renovate[bot]",
+            "github-actions[bot]",
+        ],
+    )
+    def test_common_bots_all_preserved(self, bot_login: str) -> None:
+        """All common bots keep their original author."""
+        mock_self = _make_mock_self()
+        original = f"{bot_login} <{bot_login}@github.com>"
+
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author=original,
+            pr_author_login=bot_login,
+            inputs=_make_inputs(),
+        )
+
+        assert author == original
+        assert trailer is None
+
+
+# ---------------------------------------------------------------------------
+# _get_pr_author_login
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrAuthorLogin:
+    """Test GitHub PR author login fetching."""
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    def test_returns_login_on_success(
+        self, mock_get_pull, mock_get_repo, mock_build_client
+    ) -> None:
+        """Successfully fetch PR author login."""
+        mock_pr = MagicMock()
+        mock_pr.user.login = "askb"
+        mock_get_pull.return_value = mock_pr
+
+        mock_self = _make_mock_self()
+        gh = _make_gh(pr_number="42")
+        result = Orchestrator._get_pr_author_login(mock_self, gh)
+
+        assert result == "askb"
+        mock_get_pull.assert_called_once()
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    def test_returns_empty_on_api_failure(
+        self, mock_get_pull, mock_get_repo, mock_build_client
+    ) -> None:
+        """API failure returns empty string (conservative fallback)."""
+        mock_get_pull.side_effect = Exception("API error")
+
+        mock_self = _make_mock_self()
+        gh = _make_gh(pr_number="42")
+        result = Orchestrator._get_pr_author_login(mock_self, gh)
+
+        assert result == ""
+
+    def test_returns_empty_when_no_pr_number(self) -> None:
+        """No PR number → empty string."""
+        mock_self = _make_mock_self()
+        gh = _make_gh(pr_number=None)
+        result = Orchestrator._get_pr_author_login(mock_self, gh)
+
+        assert result == ""
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    def test_returns_empty_when_user_is_none(
+        self, mock_get_pull, mock_get_repo, mock_build_client
+    ) -> None:
+        """PR with no user attribute → empty string."""
+        mock_pr = MagicMock()
+        mock_pr.user = None
+        mock_get_pull.return_value = mock_pr
+
+        mock_self = _make_mock_self()
+        gh = _make_gh(pr_number="42")
+        result = Orchestrator._get_pr_author_login(mock_self, gh)
+
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_commit_message_with_trailers — Co-authored-by injection
+# ---------------------------------------------------------------------------
+
+
+class TestCoAuthoredByTrailerInjection:
+    """Test that extra_co_authored_by is correctly added to commit messages."""
+
+    def test_extra_co_authored_by_added(self) -> None:
+        """Co-authored-by trailer is appended when provided."""
+        mock_self = _make_mock_self()
+        inputs = _make_inputs()
+        gh = _make_gh()
+
+        msg = Orchestrator._build_commit_message_with_trailers(
+            mock_self,
+            base_message="fix: resolve build issue\n\nDetailed description.",
+            inputs=inputs,
+            gh=gh,
+            extra_co_authored_by="Co-authored-by: Anil Belur <askb23@gmail.com>",
+        )
+
+        assert "Co-authored-by: Anil Belur <askb23@gmail.com>" in msg
+
+    def test_no_co_authored_by_when_none(self) -> None:
+        """No Co-authored-by added when parameter is None."""
+        mock_self = _make_mock_self()
+        inputs = _make_inputs()
+        gh = _make_gh()
+
+        msg = Orchestrator._build_commit_message_with_trailers(
+            mock_self,
+            base_message="feat: new feature",
+            inputs=inputs,
+            gh=gh,
+            extra_co_authored_by=None,
+        )
+
+        assert "Co-authored-by:" not in msg
+
+    def test_co_authored_by_dedup(self) -> None:
+        """Duplicate Co-authored-by trailers are not repeated."""
+        mock_self = _make_mock_self()
+        inputs = _make_inputs()
+        gh = _make_gh()
+
+        base = "fix: thing\n\nCo-authored-by: Anil Belur <askb23@gmail.com>"
+
+        msg = Orchestrator._build_commit_message_with_trailers(
+            mock_self,
+            base_message=base,
+            inputs=inputs,
+            gh=gh,
+            extra_co_authored_by="Co-authored-by: Anil Belur <askb23@gmail.com>",
+        )
+
+        # Should appear exactly once
+        assert msg.count("Co-authored-by: Anil Belur <askb23@gmail.com>") == 1
+
+    def test_co_authored_by_with_existing_different_author(self) -> None:
+        """New Co-authored-by alongside an existing different one."""
+        mock_self = _make_mock_self()
+        inputs = _make_inputs()
+        gh = _make_gh()
+
+        base = "fix: thing\n\nCo-authored-by: Robert Varga <rv@example.com>"
+
+        msg = Orchestrator._build_commit_message_with_trailers(
+            mock_self,
+            base_message=base,
+            inputs=inputs,
+            gh=gh,
+            extra_co_authored_by="Co-authored-by: Anil Belur <askb23@gmail.com>",
+        )
+
+        assert "Co-authored-by: Robert Varga <rv@example.com>" in msg
+        assert "Co-authored-by: Anil Belur <askb23@gmail.com>" in msg
+
+
+# ---------------------------------------------------------------------------
+# Integration: bot detection + author resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBotDetectionIntegration:
+    """End-to-end: verify bot detection feeds correctly into author resolution."""
+
+    def test_dependabot_full_flow(self) -> None:
+        """Dependabot PR: is_bot_author=True → author preserved."""
+        assert is_bot_author("dependabot[bot]") is True
+
+        mock_self = _make_mock_self()
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
+            pr_author_login="dependabot[bot]",
+            inputs=_make_inputs(),
+        )
+
+        assert "dependabot[bot]" in author
+        assert trailer is None
+
+    def test_human_developer_full_flow(self) -> None:
+        """Human developer PR: is_bot_author=False → author swapped."""
+        assert is_bot_author("rvarga") is False
+
+        mock_self = _make_mock_self()
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author="Robert Varga <rovarga@cisco.com>",
+            pr_author_login="rvarga",
+            inputs=_make_inputs(),
+        )
+
+        assert "opendaylight.gh2gerrit" in author
+        assert trailer == "Co-authored-by: Robert Varga <rovarga@cisco.com>"
+
+    def test_double_resolve_guard_skips_duplicate_swap(self) -> None:
+        """When original_author already equals the bot, skip re-resolution."""
+        mock_self = _make_mock_self()
+        inputs = _make_inputs()
+        bot_author = (
+            f"{inputs.gerrit_ssh_user_g2g} <{inputs.gerrit_ssh_user_g2g_email}>"
+        )
+
+        author, trailer = Orchestrator._resolve_author_for_gerrit(
+            mock_self,
+            original_author=bot_author,
+            pr_author_login="rvarga",  # human login
+            inputs=inputs,
+        )
+
+        # Should return the bot author unchanged, no Co-authored-by
+        assert author == bot_author
+        assert trailer is None


### PR DESCRIPTION
## Problem

When a human developer opens a GitHub PR and G2G pushes the resulting commit to Gerrit, preserving the human as the git author triggers NACR (Non-Author Code-Review) restrictions. This prevents the developer from self-approving their own G2G-submitted change on Gerrit.

**Root cause**: G2G uses `--author "Developer <email>"` in 3 code paths (multi-commit, squash, apply-pr-title). Gerrit derives the change "owner" from the git Author field, making the human developer the owner of the change, which then triggers NACR self-approval blocks.

**Reference**: https://git.opendaylight.org/gerrit/c/releng/builder/+/121153

## Solution

For **human PRs**: Swap the git author to the G2G bot identity and add a `Co-authored-by` trailer preserving the original developer attribution. This way Gerrit sees the bot as the change owner, allowing the human developer to approve.

For **bot PRs** (Dependabot, pre-commit-ci, Renovate, etc.): Keep current behavior — bots never review their own changes.

## Changes

- **New**: `bot_detection.py` — 3-level bot detection (exact match for 14 known bots, `[bot]` suffix check, word-boundary heuristic)
- **New**: `_resolve_author_for_gerrit()` helper in `Orchestrator`
- **Modified**: Multi-commit path (cherry-pick loop) for NACR-safe author
- **Modified**: Squash path for NACR-safe author
- **Modified**: Apply-pr-title path for NACR-safe author
- **Extended**: `_build_commit_message_with_trailers()` with `extra_co_authored_by` parameter

## Testing

- 44 bot detection tests (all passing)
- 19 NACR author-swap integration tests (all passing)
- Total: 63 new tests covering bot/human detection, author resolution, trailer injection, and all 3 submission paths

## Example

**Before** (human PR by `developer@example.com`):
```
Author: Developer <developer@example.com>   ← Gerrit sees this as owner → NACR blocks self-approval
```

**After** (human PR by `developer@example.com`):
```
Author: github2gerrit <github2gerrit@linuxfoundation.org>   ← Gerrit sees bot as owner
Co-authored-by: Developer <developer@example.com>            ← Attribution preserved
```

**Bot PR** (unchanged):
```
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>   ← Kept as-is
```