### PR TITLE
Fix: Add mode toggles to release-drafter

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -71,5 +71,7 @@ jobs:
       - name: 'Autolabel PR'
         # yamllint disable-line rule:line-length
         uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
+        with:
+          disable-releaser: true
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -45,5 +45,7 @@ jobs:
       - name: 'Update draft release'
         # yamllint disable-line rule:line-length
         uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
+        with:
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Release-drafter v7.1.0 runs both releaser and autolabeler modes by default. Without explicit toggles, the autolabeler workflow attempts to create a draft release and fails with `Resource not accessible by integration` because it only has `contents: read` permission.

This adds the `disable-releaser` / `disable-autolabeler` input toggles so each workflow only exercises its intended mode:

- **`autolabeler.yaml`** — `disable-releaser: true` (only labels PRs)
- **`release-drafter.yaml`** — `disable-autolabeler: true` (only drafts releases)

This matches the pattern used in [tykeal/homeassistant-turnovercal](https://github.com/tykeal/homeassistant-turnovercal/blob/main/.github/workflows/release-drafter.yaml).