### PR TITLE
Fix: use v7 autolabeler sub-action

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -55,23 +55,5 @@ jobs:
         with:
           egress-policy: 'audit'
 
-      - name: 'Show concurrency group'
-        shell: bash
-        # yamllint disable rule:line-length
-        run: |
-          # Show concurrency group
-          GROUP="${{ format('al-{0}-pr-{1}', github.event_name, github.event.pull_request.number) }}"
-          {
-            echo '## Autolabeler'
-            echo "Concurrency group: ${GROUP}"
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "Concurrency group: ${GROUP}"
-        # yamllint enable rule:line-length
-
-      - name: 'Autolabel PR'
-        # yamllint disable-line rule:line-length
-        uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
-        with:
-          disable-releaser: true
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter/autolabeler@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -13,7 +13,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: "rd-push-${{ github.ref }}"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,21 +31,5 @@ jobs:
         with:
           egress-policy: 'audit'
 
-      - name: 'Show concurrency group'
-        shell: bash
-        run: |
-          # Show concurrency group
-          GROUP="rd-push-${{ github.ref }}"
-          {
-            echo '## Release Drafter'
-            echo "Concurrency group: ${GROUP}"
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "Concurrency group: ${GROUP}"
-
-      - name: 'Update draft release'
-        # yamllint disable-line rule:line-length
-        uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
-        with:
-          disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0


### PR DESCRIPTION
## Summary

Fix the autolabeler workflow failure on all PRs by migrating to the v7 dedicated autolabeler sub-action and cleaning up both workflows.

## Problem

The autolabeler workflow was invoking the root drafter action (`release-drafter/release-drafter@v7.1.0`) with `disable-releaser: true`. However, the [v7 rewrite](https://github.com/release-drafter/release-drafter/pull/1475) explicitly removed support for `disable-releaser` / `disable-autolabeler` as a **breaking change**, replacing them with separate sub-actions:

> **move Autolabeler to a dedicated action. The corresponding `disable-releaser` and `disable-autolabeler` were removed.**

The inputs still exist in `action.yml` but are dead code — they are never read or acted upon. The drafter unconditionally runs its full release pipeline, attempts to create a release, and fails with:

```
Error: Resource not accessible by integration
```

because the autolabeler workflow only has `contents: read`.

This is the root cause of the "Autolabel PR" check failure on PRs #164, #167, and #168.

## Changes

### `autolabeler.yaml`
- Switch from `release-drafter/release-drafter@v7.1.0` to `release-drafter/release-drafter/autolabeler@v7.1.0` (the dedicated v7 sub-action)
- Remove the dead `disable-releaser: true` input
- Remove the deprecated `env: GITHUB_TOKEN` (v7 defaults to `${{ github.token }}` via the `token` input)
- Remove the "Show concurrency group" debug step (see rationale below)

### `release-drafter.yaml`
- Remove the dead `disable-autolabeler: true` input
- Remove the deprecated `env: GITHUB_TOKEN`
- Remove the "Show concurrency group" debug step (see rationale below)
- Align concurrency group to the standard `${{ github.workflow }}-${{ github.ref }}` pattern

### Why remove the concurrency group debug steps?

The "Show concurrency group" steps were added when both workflows shared complex conditional concurrency groups that handled multiple event types (`push`, `pull_request`, `pull_request_target`) within a single workflow. With the v7 split into dedicated workflows, each workflow now handles exactly one concern:

- `release-drafter.yaml` only triggers on `push` — concurrency is simply `workflow-ref`
- `autolabeler.yaml` only triggers on PR events — concurrency is `event-pr_number`

These are straightforward patterns that don't need runtime debugging. Removing the steps reduces workflow noise and aligns with the [canonical v7 migration pattern](https://github.com/tykeal/homeassistant-turnovercal/pull/8).

## Reference

- [release-drafter/release-drafter#1475](https://github.com/release-drafter/release-drafter/pull/1475) — v7 breaking changes documentation
- [tykeal/homeassistant-turnovercal#8](https://github.com/tykeal/homeassistant-turnovercal/pull/8) — canonical v7 migration example
- [release-drafter/release-drafter#1562](https://github.com/release-drafter/release-drafter/issues/1562) — upstream bug report for the dead inputs