### PR TITLE
Fix: CC prefix truncation and auto-supersede dependency changes

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,12 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: "CodeQL Advanced Configuration File"
+
+# Exclude test files from CodeQL analysis; CodeQL
+# only runs AFTER submission of pull requests and
+# tests cause false positives in security audits.
+
+paths-ignore:
+  - tests

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -2226,7 +2226,7 @@ def _process() -> None:
             ):
                 try:
                     log.debug(
-                        "🔍 Checking for Gerrit change to abandon for PR #%s",
+                        "Checking for Gerrit change to abandon for PR #%s",
                         gh.pr_number,
                     )
                     change_number = abandon_gerrit_change_for_closed_pr(
@@ -2238,16 +2238,29 @@ def _process() -> None:
                         progress_tracker=None,
                     )
                     if change_number:
-                        gerrit_change_url = (
-                            f"https://{data.gerrit_server}/c/"
-                            f"{data.gerrit_project}/+/{change_number}"
-                        )
-                        log.debug(
-                            "✅ Successfully abandoned Gerrit change %s "
-                            "for pull request #%s",
-                            gerrit_change_url,
-                            gh.pr_number,
-                        )
+                        try:
+                            from .gerrit_urls import create_gerrit_url_builder
+
+                            _url_builder = create_gerrit_url_builder(
+                                data.gerrit_server
+                            )
+                            gerrit_change_url = _url_builder.change_url(
+                                data.gerrit_project,
+                                int(change_number),
+                            )
+                            log.debug(
+                                "Successfully abandoned Gerrit "
+                                "change %s for pull request #%s",
+                                gerrit_change_url,
+                                gh.pr_number,
+                            )
+                        except (ValueError, TypeError):
+                            log.debug(
+                                "Successfully abandoned Gerrit "
+                                "change %s for pull request #%s",
+                                change_number,
+                                gh.pr_number,
+                            )
                         # Console output already done by
                         # abandon_gerrit_change_for_closed_pr
                     else:
@@ -2295,7 +2308,7 @@ def _process() -> None:
                     log.warning("Gerrit cleanup failed: %s", exc)
 
             log.debug(
-                "✅ Cleanup operations completed for closed PR #%s",
+                "Cleanup operations completed for closed PR #%s",
                 gh.pr_number or "unknown",
             )
             return

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -2254,7 +2254,7 @@ def _process() -> None:
                                 gerrit_change_url,
                                 gh.pr_number,
                             )
-                        except (ValueError, TypeError):
+                        except Exception:
                             log.debug(
                                 "Successfully abandoned Gerrit "
                                 "change %s for pull request #%s",

--- a/src/github2gerrit/commit_normalization.py
+++ b/src/github2gerrit/commit_normalization.py
@@ -401,8 +401,9 @@ class CommitNormalizer:
         # Remove trailing ellipsis
         title = re.sub(r"\s*[.]{3,}.*$", "", title)
 
-        # Remove markdown formatting
-        title = re.sub(r"[*_`]", "", title)
+        # Remove markdown bold/code formatting but preserve underscores
+        # (which appear in package names and filesystem paths).
+        title = re.sub(r"[*`]", "", title)
 
         # For dependabot titles, extract the essential information
         for pattern in DEPENDABOT_PATTERNS:

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -194,14 +194,24 @@ def _clean_squash_title_line(title_line: str | None) -> str:
         cc_prefix_len = cc_match.end() if cc_match else 0
 
         break_points = [". ", "! ", "? ", " - ", ": "]
+        max_bp_len = max(len(bp) for bp in break_points)
         truncated = False
         for bp in break_points:
             # For the ": " break-point, start searching after the
             # conventional commit prefix to avoid splitting there.
             search_start = cc_prefix_len if bp == ": " else 0
-            candidate = title_line[search_start:100]
-            if bp in candidate:
-                bp_idx = title_line.index(bp, search_start)
+            # Extend the slice by (max_bp_len - 1) so that a
+            # break-point starting just before position 100 is
+            # still detected even if it spans across the boundary.
+            candidate_end = min(len(title_line), 100 + max_bp_len - 1)
+            candidate = title_line[search_start:candidate_end]
+            bp_offset = candidate.find(bp)
+            if bp_offset != -1:
+                bp_idx = search_start + bp_offset
+                # Only use this break-point if it starts within
+                # the 100-char limit.
+                if bp_idx >= 100:
+                    continue
                 # Punctuation break-points (". ", ": ") — include
                 # the punctuation mark.  Separator break-points
                 # (" - ") — truncate before the separator.

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -154,17 +154,7 @@ def _clean_ellipses_from_message(message: str) -> str:
     return "\n".join(cleaned_lines)
 
 
-# Pattern to match conventional commit prefixes like "feat:", "fix(scope):",
-# "Build(deps)!:" etc.  Used by _clean_squash_title_line to prevent the
-# truncation algorithm from splitting on the prefix separator.
-_CC_PREFIX_RE = re.compile(
-    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
-    r"(\(.+?\))?\s*!?\s*:\s*",
-    re.IGNORECASE,
-)
-
-
-def _clean_squash_title_line(title_line: str) -> str:
+def _clean_squash_title_line(title_line: str | None) -> str:
     """Clean and truncate a squashed commit title line.
 
     Handles markdown removal, separator splitting, and length
@@ -177,6 +167,11 @@ def _clean_squash_title_line(title_line: str) -> str:
     Returns:
         Cleaned title line, safe for use as a commit subject.
     """
+    from .similarity import CC_PREFIX_RE
+
+    if not title_line:
+        return ""
+
     # Remove markdown links
     title_line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title_line)
     # Remove trailing ellipsis/truncation
@@ -195,7 +190,7 @@ def _clean_squash_title_line(title_line: str) -> str:
         # ": " break-point does not split on the prefix separator
         # (e.g. "Build(deps): " should not be treated as a sentence
         # break).
-        cc_match = _CC_PREFIX_RE.match(title_line)
+        cc_match = CC_PREFIX_RE.match(title_line)
         cc_prefix_len = cc_match.end() if cc_match else 0
 
         break_points = [". ", "! ", "? ", " - ", ": "]
@@ -207,7 +202,15 @@ def _clean_squash_title_line(title_line: str) -> str:
             candidate = title_line[search_start:100]
             if bp in candidate:
                 bp_idx = title_line.index(bp, search_start)
-                title_line = title_line[: bp_idx + len(bp.strip())]
+                # Punctuation break-points (". ", ": ") — include
+                # the punctuation mark.  Separator break-points
+                # (" - ") — truncate before the separator.
+                if bp[0].isspace():
+                    title_line = title_line[:bp_idx].rstrip()
+                else:
+                    title_line = title_line[
+                        : bp_idx + len(bp.rstrip())
+                    ].rstrip()
                 truncated = True
                 break
 
@@ -752,6 +755,9 @@ class Orchestrator:
         2. GitHub-Hash trailer matching
         3. GitHub-PR trailer URL matching
         4. Mapping comment parsing from PR comments
+        5. Dependency package match — find an open change that
+           bumps the same dependency (for Dependabot / Renovate
+           supersession).
 
         Args:
             gh: GitHub context containing PR information
@@ -867,6 +873,10 @@ class Orchestrator:
             except Exception as exc:
                 log.debug("GitHub-Hash trailer query failed: %s", exc)
 
+        # Cache the PR title for reuse across strategies 4 and 5
+        # so we don't duplicate GitHub API requests.
+        cached_pr_title: str = ""
+
         # Strategy 4: Parse mapping comments from PR
         try:
             from .mapping_comment import parse_mapping_comments
@@ -874,6 +884,7 @@ class Orchestrator:
             client_gh = build_client()
             repo = get_repo_from_env(client_gh)
             pr_obj = get_pull(repo, int(gh.pr_number))
+            cached_pr_title = getattr(pr_obj, "title", "") or ""
 
             issue = pr_obj.as_issue()
             comments = list(issue.get_comments())
@@ -903,6 +914,110 @@ class Orchestrator:
 
         except Exception as exc:
             log.debug("Mapping comment parsing failed: %s", exc)
+
+        # Strategy 5: Dependency package match (supersession)
+        # When a new Dependabot/Renovate PR bumps the same dependency
+        # as an existing open Gerrit change, reuse that Change-Id so
+        # the push creates a new patchset instead of a duplicate change.
+        try:
+            from .gerrit_query import GerritChange
+            from .gerrit_query import query_open_changes_by_project
+            from .gerrit_rest import build_client_for_host
+            from .similarity import extract_dependency_package_from_subject
+            from .trailers import GITHUB_PR_TRAILER
+            from .trailers import parse_trailers
+
+            # Reuse PR title cached by Strategy 4 to avoid a
+            # duplicate GitHub API request.
+            pr_title = cached_pr_title
+            if not pr_title:
+                log.debug(
+                    "Strategy 5: PR title cache miss, fetching from GitHub API",
+                )
+                try:
+                    gh_client = build_client()
+                    gh_repo = get_repo_from_env(gh_client)
+                    pr_obj = get_pull(gh_repo, int(gh.pr_number))
+                    pr_title = getattr(pr_obj, "title", "") or ""
+                except Exception:
+                    pr_title = ""
+
+            current_pkg = extract_dependency_package_from_subject(pr_title)
+            if current_pkg:
+                log.debug(
+                    "Strategy 5: searching for open changes that "
+                    "bump dependency '%s'",
+                    current_pkg,
+                )
+                dep_client = build_client_for_host(gerrit.host)
+                open_changes = query_open_changes_by_project(
+                    dep_client,
+                    gerrit.project,
+                    branch=gh.base_ref,
+                    max_results=200,
+                )
+
+                # Collect all matching changes, then select the
+                # oldest one (lowest change number) to avoid
+                # "downgrading" a newer change by uploading an
+                # older patchset to it.
+                candidates: list[tuple[int, GerritChange]] = []
+                for change in open_changes:
+                    candidate_pkg = extract_dependency_package_from_subject(
+                        change.subject
+                    )
+                    if candidate_pkg and candidate_pkg == current_pkg:
+                        # Verify this is a GitHub2Gerrit change
+                        commit_msg = change.commit_message or ""
+                        trailers = parse_trailers(commit_msg)
+                        if GITHUB_PR_TRAILER not in trailers:
+                            log.debug(
+                                "Strategy 5: skipping change %s "
+                                "(no GitHub2Gerrit metadata)",
+                                change.number,
+                            )
+                            continue
+                        try:
+                            change_num = int(change.number)
+                        except (TypeError, ValueError):
+                            log.debug(
+                                "Strategy 5: skipping change with "
+                                "invalid number %r for subject %r",
+                                change.number,
+                                change.subject,
+                            )
+                            continue
+                        candidates.append((change_num, change))
+
+                if candidates:
+                    # Prefer the oldest open change so the newest
+                    # PR always updates the original change and
+                    # the post-push sweep abandons the rest.
+                    candidates.sort(key=lambda t: t[0])
+                    _, oldest = candidates[0]
+                    change_ids = [oldest.change_id]
+                    log.info(
+                        "Found superseding target by dependency "
+                        "package '%s': change %s (%s) "
+                        "(oldest of %d candidate(s))",
+                        current_pkg,
+                        oldest.number,
+                        oldest.subject,
+                        len(candidates),
+                    )
+                    return change_ids
+
+                log.debug(
+                    "No open changes found for dependency '%s'",
+                    current_pkg,
+                )
+            else:
+                log.debug(
+                    "Strategy 5 skipped: could not extract dependency "
+                    "package from PR title"
+                )
+        except Exception as exc:
+            log.debug("Dependency package strategy failed: %s", exc)
 
         log.warning(
             "⚠️  No existing Gerrit changes found for PR #%s",
@@ -2009,6 +2124,49 @@ class Orchestrator:
 
         # Validate that no unexpected files were committed
         self._validate_committed_files(gh, result)
+
+        # Post-push supersession sweep (Option A fallback).
+        # After a successful push, check whether other open Gerrit
+        # changes in the same project bump the same dependency
+        # package.  If Strategy 5 already reused the old Change-Id
+        # (update-in-place), no duplicates should exist.  If that
+        # path was skipped (e.g. non-dependency PR, or the query
+        # failed), this sweep catches and abandons stale changes.
+        if not inputs.dry_run and gerrit and prep.change_ids:
+            try:
+                from .gerrit_pr_closer import (
+                    abandon_superseded_dependency_changes,
+                )
+
+                # Derive the subject from the pushed commit,
+                # regardless of whether change URL lookup
+                # succeeded.
+                push_subject = ""
+                try:
+                    push_subject = run_cmd(
+                        [
+                            "git",
+                            "show",
+                            "-s",
+                            "--pretty=format:%s",
+                            "HEAD",
+                        ],
+                        cwd=self.workspace,
+                    ).stdout.strip()
+                except Exception:
+                    push_subject = ""
+
+                if push_subject:
+                    abandon_superseded_dependency_changes(
+                        gerrit_server=gerrit.host,
+                        gerrit_project=gerrit.project,
+                        current_subject=push_subject,
+                        exclude_change_ids=prep.change_ids,
+                        dry_run=False,
+                        target_branch=self._resolve_target_branch(),
+                    )
+            except Exception as exc:
+                log.debug("Post-push supersession sweep skipped: %s", exc)
 
         self._close_pull_request_if_required(gh)
 

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -154,6 +154,80 @@ def _clean_ellipses_from_message(message: str) -> str:
     return "\n".join(cleaned_lines)
 
 
+# Pattern to match conventional commit prefixes like "feat:", "fix(scope):",
+# "Build(deps)!:" etc.  Used by _clean_squash_title_line to prevent the
+# truncation algorithm from splitting on the prefix separator.
+_CC_PREFIX_RE = re.compile(
+    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
+    r"(\(.+?\))?\s*!?\s*:\s*",
+    re.IGNORECASE,
+)
+
+
+def _clean_squash_title_line(title_line: str) -> str:
+    """Clean and truncate a squashed commit title line.
+
+    Handles markdown removal, separator splitting, and length
+    truncation while preserving conventional commit prefixes
+    and underscores in package/path names.
+
+    Args:
+        title_line: Raw title line from git log output.
+
+    Returns:
+        Cleaned title line, safe for use as a commit subject.
+    """
+    # Remove markdown links
+    title_line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title_line)
+    # Remove trailing ellipsis/truncation
+    title_line = re.sub(r"\s*[.]{3,}.*$", "", title_line)
+    # Split on common separators to avoid leaking body content
+    for separator in [". Bumps ", " Bumps ", ". - ", " - "]:
+        if separator in title_line:
+            title_line = title_line.split(separator)[0].strip()
+            break
+    # Remove markdown bold/code formatting but preserve underscores
+    # (which appear in package names and filesystem paths).
+    title_line = re.sub(r"[*`]", "", title_line).strip()
+
+    if len(title_line) > 100:
+        # Detect conventional commit prefix length so that the
+        # ": " break-point does not split on the prefix separator
+        # (e.g. "Build(deps): " should not be treated as a sentence
+        # break).
+        cc_match = _CC_PREFIX_RE.match(title_line)
+        cc_prefix_len = cc_match.end() if cc_match else 0
+
+        break_points = [". ", "! ", "? ", " - ", ": "]
+        truncated = False
+        for bp in break_points:
+            # For the ": " break-point, start searching after the
+            # conventional commit prefix to avoid splitting there.
+            search_start = cc_prefix_len if bp == ": " else 0
+            candidate = title_line[search_start:100]
+            if bp in candidate:
+                bp_idx = title_line.index(bp, search_start)
+                title_line = title_line[: bp_idx + len(bp.strip())]
+                truncated = True
+                break
+
+        if not truncated and cc_prefix_len == 0:
+            # Non-CC title with no break-point found: fall back
+            # to word-boundary truncation at 100 characters.
+            words = title_line[:100].split()
+            title_line = (
+                " ".join(words[:-1])
+                if len(words) > 1
+                else title_line[:100].rstrip()
+            )
+        # For CC titles with no break-point: pass through the
+        # full title.  The length is inherent to the structured
+        # subject (e.g. long dependency paths), not body-content
+        # leakage.
+
+    return title_line
+
+
 # ---------------------
 # Utility functions
 # ---------------------
@@ -3564,32 +3638,7 @@ class Orchestrator:
             return message_lines, signed_off, change_ids
 
         def _clean_title_line(title_line: str) -> str:
-            # Remove markdown links
-            title_line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title_line)
-            # Remove trailing ellipsis/truncation
-            title_line = re.sub(r"\s*[.]{3,}.*$", "", title_line)
-            # Split on common separators to avoid leaking body content
-            for separator in [". Bumps ", " Bumps ", ". - ", " - "]:
-                if separator in title_line:
-                    title_line = title_line.split(separator)[0].strip()
-                    break
-            # Remove simple markdown/formatting artifacts
-            title_line = re.sub(r"[*_`]", "", title_line).strip()
-            if len(title_line) > 100:
-                break_points = [". ", "! ", "? ", " - ", ": "]
-                for bp in break_points:
-                    if bp in title_line[:100]:
-                        title_line = title_line[
-                            : title_line.index(bp) + len(bp.strip())
-                        ]
-                        break
-                else:
-                    words = title_line[:100].split()
-                    title_line = (
-                        " ".join(words[:-1])
-                        if len(words) > 1
-                        else title_line[:100].rstrip()
-                    )
+            title_line = _clean_squash_title_line(title_line)
 
             # Apply conventional commit normalization if enabled
             if inputs.normalise_commit and gh.pr_number:

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -61,18 +61,21 @@ def _build_gerrit_change_url(
 ) -> str | None:
     """Build a Gerrit change URL from a change number string.
 
-    Returns the URL string, or ``None`` when *change_number* cannot
-    be parsed as an integer.
+    Returns the URL string, or ``None`` when URL generation fails.
     """
     try:
         from .gerrit_urls import create_gerrit_url_builder
 
         url_builder = create_gerrit_url_builder(gerrit_server)
         return url_builder.change_url(gerrit_project, int(change_number))
-    except (ValueError, TypeError):
+    except Exception:
         log.debug(
-            "Could not parse change number %r as int; skipping URL generation",
+            "Could not build Gerrit change URL for server=%r, project=%r, "
+            "change_number=%r; skipping URL generation",
+            gerrit_server,
+            gerrit_project,
             change_number,
+            exc_info=True,
         )
         return None
 

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -54,6 +54,29 @@ FORCE_ABANDONED_CLEANUP = _env_bool("CLEANUP_ABANDONED", True)
 FORCE_GERRIT_CLEANUP = _env_bool("CLEANUP_GERRIT", True)
 
 
+def _build_gerrit_change_url(
+    gerrit_server: str,
+    gerrit_project: str,
+    change_number: str,
+) -> str | None:
+    """Build a Gerrit change URL from a change number string.
+
+    Returns the URL string, or ``None`` when *change_number* cannot
+    be parsed as an integer.
+    """
+    try:
+        from .gerrit_urls import create_gerrit_url_builder
+
+        url_builder = create_gerrit_url_builder(gerrit_server)
+        return url_builder.change_url(gerrit_project, int(change_number))
+    except (ValueError, TypeError):
+        log.debug(
+            "Could not parse change number %r as int; skipping URL generation",
+            change_number,
+        )
+        return None
+
+
 def extract_change_number_from_url(
     gerrit_change_url: str,
 ) -> tuple[str, str] | None:
@@ -1078,7 +1101,7 @@ def abandon_gerrit_change_for_closed_pr(
         (or would be in dry-run), None otherwise
     """
     log.debug(
-        "🔍 Looking for Gerrit change associated with PR #%d",
+        "Looking for Gerrit change associated with PR #%d",
         pr_number,
     )
 
@@ -1232,24 +1255,35 @@ def abandon_gerrit_change_for_closed_pr(
 
             # Abandon the Gerrit change
             if not dry_run:
-                gerrit_change_url = (
-                    f"https://{gerrit_server}/c/"
-                    f"{gerrit_project}/+/{change_number}"
+                gerrit_change_url = _build_gerrit_change_url(
+                    gerrit_server, gerrit_project, change_number
                 )
                 _abandon_gerrit_change(
                     gerrit_client,
                     change_number,
                     abandon_message,
                 )
-                log.debug(
-                    "✅ Abandoned Gerrit change %s: %s",
-                    change_number,
-                    gerrit_change_url,
-                )
-                safe_console_print(
-                    f"✅ Abandoned Gerrit change {gerrit_change_url} "
-                    f"for pull request #{pr_number}"
-                )
+                if gerrit_change_url:
+                    log.debug(
+                        "Abandoned Gerrit change %s: %s",
+                        change_number,
+                        gerrit_change_url,
+                    )
+                    safe_console_print(
+                        f"✅ Abandoned Gerrit change "
+                        f"{gerrit_change_url} "
+                        f"for pull request #{pr_number}"
+                    )
+                else:
+                    log.debug(
+                        "Abandoned Gerrit change %s",
+                        change_number,
+                    )
+                    safe_console_print(
+                        f"✅ Abandoned Gerrit change "
+                        f"{change_number} "
+                        f"for pull request #{pr_number}"
+                    )
             else:
                 log.debug(
                     "DRY-RUN: Would abandon Gerrit change %s",
@@ -1274,9 +1308,8 @@ def abandon_gerrit_change_for_closed_pr(
             )
 
             if not dry_run:
-                gerrit_change_url = (
-                    f"https://{gerrit_server}/c/"
-                    f"{gerrit_project}/+/{change_number}"
+                gerrit_change_url = _build_gerrit_change_url(
+                    gerrit_server, gerrit_project, change_number
                 )
                 _abandon_gerrit_change(
                     gerrit_client,
@@ -1284,10 +1317,18 @@ def abandon_gerrit_change_for_closed_pr(
                     simple_message,
                 )
                 log.debug("Abandoned Gerrit change %s", change_number)
-                safe_console_print(
-                    f"✅ Abandoned Gerrit change {gerrit_change_url} "
-                    f"for pull request #{pr_number}"
-                )
+                if gerrit_change_url:
+                    safe_console_print(
+                        f"✅ Abandoned Gerrit change "
+                        f"{gerrit_change_url} "
+                        f"for pull request #{pr_number}"
+                    )
+                else:
+                    safe_console_print(
+                        f"✅ Abandoned Gerrit change "
+                        f"{change_number} "
+                        f"for pull request #{pr_number}"
+                    )
             else:
                 log.debug(
                     "DRY-RUN: Would abandon Gerrit change %s",
@@ -1454,20 +1495,25 @@ def cleanup_closed_github_prs(
 
                     # Abandon the Gerrit change
                     if not dry_run:
-                        gerrit_change_url = (
-                            f"https://{gerrit_server}/c/"
-                            f"{gerrit_project}/+/{change_number}"
+                        gerrit_change_url = _build_gerrit_change_url(
+                            gerrit_server, gerrit_project, change_number
                         )
                         _abandon_gerrit_change(
                             gerrit_client,
                             change_number,
                             abandon_message,
                         )
-                        log.info(
-                            "Abandoned Gerrit change %s: %s",
-                            change_number,
-                            gerrit_change_url,
-                        )
+                        if gerrit_change_url:
+                            log.info(
+                                "Abandoned Gerrit change %s: %s",
+                                change_number,
+                                gerrit_change_url,
+                            )
+                        else:
+                            log.info(
+                                "Abandoned Gerrit change %s",
+                                change_number,
+                            )
                     else:
                         log.info(
                             "DRY-RUN: Would abandon Gerrit change %s",
@@ -1652,3 +1698,157 @@ def _abandon_gerrit_change(
     except Exception:
         log.exception("Failed to abandon Gerrit change %s", change_number)
         raise
+
+
+def abandon_superseded_dependency_changes(
+    gerrit_server: str,
+    gerrit_project: str,
+    current_subject: str,
+    exclude_change_ids: list[str],
+    *,
+    dry_run: bool = False,
+    target_branch: str | None = None,
+) -> list[str]:
+    """Abandon open Gerrit changes superseded by a newer dependency update.
+
+    After pushing a new dependency-update change, this function
+    queries Gerrit for other open changes in the same project that
+    bump the **same** dependency package.  Matches are abandoned
+    with an explanatory message.
+
+    This serves as the "Option A fallback" when the primary
+    update-in-place strategy (Change-Id reuse) could not be
+    applied.
+
+    Args:
+        gerrit_server: Gerrit server hostname.
+        gerrit_project: Gerrit project name.
+        current_subject: Subject of the change that was just pushed.
+        exclude_change_ids: Change-IDs to exclude (the change we
+            just pushed, so we don't abandon ourselves).
+        dry_run: If True, log but do not actually abandon.
+        target_branch: Optional Gerrit branch name.  When provided,
+            only changes targeting this branch are considered.
+
+    Returns:
+        List of Gerrit change numbers that were abandoned
+        (or would be in dry-run mode).
+    """
+    from .gerrit_query import query_open_changes_by_project
+    from .gerrit_rest import build_client_for_host
+    from .gerrit_urls import create_gerrit_url_builder
+    from .similarity import extract_dependency_package_from_subject
+    from .trailers import GITHUB_PR_TRAILER
+    from .trailers import parse_trailers
+
+    current_pkg = extract_dependency_package_from_subject(current_subject)
+    if not current_pkg:
+        log.debug(
+            "Cannot extract dependency package from subject: %s",
+            current_subject,
+        )
+        return []
+
+    log.info(
+        "Checking for superseded dependency changes (package: %s)",
+        current_pkg,
+    )
+
+    abandoned: list[str] = []
+    try:
+        client = build_client_for_host(gerrit_server)
+        open_changes = query_open_changes_by_project(
+            client, gerrit_project, branch=target_branch, max_results=200
+        )
+
+        url_builder = create_gerrit_url_builder(gerrit_server)
+
+        for change in open_changes:
+            # Skip the change(s) we just pushed
+            if change.change_id in exclude_change_ids:
+                continue
+
+            # Only target changes created by GitHub2Gerrit
+            commit_msg = change.commit_message or ""
+            trailers = parse_trailers(commit_msg)
+            if GITHUB_PR_TRAILER not in trailers:
+                log.debug(
+                    "Skipping change %s: no GitHub2Gerrit "
+                    "metadata (missing %s trailer)",
+                    change.number,
+                    GITHUB_PR_TRAILER,
+                )
+                continue
+
+            candidate_pkg = extract_dependency_package_from_subject(
+                change.subject
+            )
+            if not candidate_pkg or candidate_pkg != current_pkg:
+                continue
+
+            # Parse change number for URL construction
+            try:
+                candidate_num = int(change.number)
+            except (TypeError, ValueError):
+                log.debug(
+                    "Skipping change with unparsable number: %r",
+                    change.number,
+                )
+                continue
+
+            change_url = url_builder.change_url(gerrit_project, candidate_num)
+            log.info(
+                "Found superseded change %s (%s)",
+                change.number,
+                change.subject,
+            )
+
+            if dry_run:
+                log.info(
+                    "DRY-RUN: Would abandon superseded change %s",
+                    change_url,
+                )
+                abandoned.append(str(change.number))
+                continue
+
+            superseding_info = f"New change subject: {current_subject}"
+            if exclude_change_ids:
+                superseding_info += "\nChange-Id(s): " + ", ".join(
+                    str(cid) for cid in exclude_change_ids
+                )
+            abandon_msg = (
+                f"Superseded by a newer update for {current_pkg}\n\n"
+                f"{superseding_info}\n\n"
+                "This change was automatically abandoned by "
+                "GitHub2Gerrit because a newer dependency update "
+                "for the same package was pushed."
+            )
+            try:
+                _abandon_gerrit_change(client, str(change.number), abandon_msg)
+                log.info(
+                    "Abandoned superseded change: %s",
+                    change_url,
+                )
+                abandoned.append(str(change.number))
+            except Exception as exc:
+                log.warning(
+                    "Failed to abandon superseded change %s: %s",
+                    change_url,
+                    exc,
+                )
+
+    except Exception as exc:
+        log.warning(
+            "Superseded dependency change sweep failed (non-fatal): %s",
+            exc,
+        )
+
+    if abandoned:
+        log.info(
+            "Supersession sweep complete: abandoned %d change(s)",
+            len(abandoned),
+        )
+    else:
+        log.debug("No superseded dependency changes found")
+
+    return abandoned

--- a/src/github2gerrit/gerrit_query.py
+++ b/src/github2gerrit/gerrit_query.py
@@ -18,6 +18,20 @@ from .gerrit_rest import GerritRestClient
 log = logging.getLogger(__name__)
 
 
+def _gerrit_quote(value: str) -> str:
+    """Escape a value for safe use inside Gerrit query double-quotes.
+
+    Gerrit query syntax uses double-quoted strings for values
+    containing special characters.  Backslashes and double-quotes
+    inside the value must be escaped to prevent query injection or
+    malformed queries (e.g. branch names containing ``"``).
+
+    Returns:
+        The escaped string (without surrounding quotes).
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 @dataclass
 class GerritChange:
     """Represents a Gerrit change from query results."""
@@ -83,7 +97,7 @@ def query_changes_by_topic(
 
     # Build query string
     status_query = " OR ".join(f"status:{status}" for status in statuses)
-    query = f'topic:"{topic}" AND ({status_query})'
+    query = f'topic:"{_gerrit_quote(topic)}" AND ({status_query})'
 
     log.debug("Querying Gerrit for changes: %s", query)
 
@@ -131,9 +145,9 @@ def query_open_changes_by_project(
     Returns:
         List of open ``GerritChange`` objects.
     """
-    query = f'project:"{project}" status:open owner:self'
+    query = f'project:"{_gerrit_quote(project)}" status:open owner:self'
     if branch:
-        query += f' branch:"{branch}"'
+        query += f' branch:"{_gerrit_quote(branch)}"'
     log.debug("Querying Gerrit for open changes: %s", query)
 
     try:

--- a/src/github2gerrit/gerrit_query.py
+++ b/src/github2gerrit/gerrit_query.py
@@ -10,6 +10,7 @@ based on topics, with support for pagination and safe parsing.
 import logging
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 
 from .gerrit_rest import GerritRestClient
 
@@ -82,7 +83,7 @@ def query_changes_by_topic(
 
     # Build query string
     status_query = " OR ".join(f"status:{status}" for status in statuses)
-    query = f"topic:{topic} AND ({status_query})"
+    query = f'topic:"{topic}" AND ({status_query})'
 
     log.debug("Querying Gerrit for changes: %s", query)
 
@@ -99,6 +100,56 @@ def query_changes_by_topic(
     except Exception as exc:
         log.warning(
             "Failed to query Gerrit changes for topic '%s': %s", topic, exc
+        )
+        return []
+    else:
+        return changes
+
+
+def query_open_changes_by_project(
+    client: GerritRestClient,
+    project: str,
+    *,
+    branch: str | None = None,
+    max_results: int = 100,
+) -> list[GerritChange]:
+    """Query open changes owned by the current user in a Gerrit project.
+
+    Used by the supersession sweep to discover open changes that
+    may be superseded by a newer dependency update.  Only returns
+    changes owned by the authenticated user (``owner:self``) to
+    avoid acting on unrelated human-authored changes.
+
+    Args:
+        client: Gerrit REST client.
+        project: Gerrit project name (e.g. ``myorg/myrepo``).
+        branch: Optional Gerrit branch name to scope the query.
+            When provided, only changes targeting this branch are
+            returned.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        List of open ``GerritChange`` objects.
+    """
+    query = f'project:"{project}" status:open owner:self'
+    if branch:
+        query += f' branch:"{branch}"'
+    log.debug("Querying Gerrit for open changes: %s", query)
+
+    try:
+        changes = _execute_query_with_pagination(
+            client, query, max_results=max_results
+        )
+        log.debug(
+            "Found %d open changes in project '%s'",
+            len(changes),
+            project,
+        )
+    except Exception as exc:
+        log.warning(
+            "Failed to query open Gerrit changes for project '%s': %s",
+            project,
+            exc,
         )
         return []
     else:
@@ -135,7 +186,7 @@ def _execute_query_with_pagination(
             # Build query URL with parameters
             # Gerrit REST API: /changes/?q=query&n=limit&S=skip&o=options
             query_params = [
-                f"q={query}",
+                f"q={quote(query, safe='')}",
                 f"n={current_limit}",
                 f"S={start}",
                 "o=CURRENT_REVISION",

--- a/src/github2gerrit/netrc.py
+++ b/src/github2gerrit/netrc.py
@@ -769,9 +769,8 @@ def resolve_gerrit_credentials(
 
     if env_user and env_pass:
         log.debug(
-            "Using credentials from environment variables %s/%s",
+            "Using credentials from environment variable %s",
             env_username_var,
-            env_password_var,
         )
         return GerritCredentials(
             username=env_user,
@@ -787,9 +786,8 @@ def resolve_gerrit_credentials(
 
         if fallback_user and fallback_pass:
             log.debug(
-                "Using credentials from fallback environment variables %s/%s",
+                "Using credentials from fallback environment variable %s",
                 fallback_env_username_var,
-                fallback_env_password_var,
             )
             return GerritCredentials(
                 username=fallback_user,
@@ -803,9 +801,9 @@ def resolve_gerrit_credentials(
         fallback_user = os.getenv(fallback_env_username_var, "").strip()
         if fallback_user and env_pass:
             log.debug(
-                "Using credentials from mixed environment variables %s/%s",
+                "Using credentials from mixed environment variables"
+                " (%s + fallback password)",
                 fallback_env_username_var,
-                env_password_var,
             )
             return GerritCredentials(
                 username=fallback_user,

--- a/src/github2gerrit/netrc.py
+++ b/src/github2gerrit/netrc.py
@@ -802,7 +802,7 @@ def resolve_gerrit_credentials(
         if fallback_user and env_pass:
             log.debug(
                 "Using credentials from mixed environment variables"
-                " (%s + fallback password)",
+                " (%s + primary password)",
                 fallback_env_username_var,
             )
             return GerritCredentials(

--- a/src/github2gerrit/pr_content_filter.py
+++ b/src/github2gerrit/pr_content_filter.py
@@ -112,7 +112,7 @@ class DependabotRule(FilterRule):
             "Bumps " in title and " from " in title and " to " in title,
             "Dependabot will resolve any conflicts" in body,
             "<details>" in body and "<summary>" in body,
-            "camo.githubusercontent.com" in body,
+            "https://camo.githubusercontent.com/" in body,
         ]
 
         # Require multiple indicators for confidence

--- a/src/github2gerrit/similarity.py
+++ b/src/github2gerrit/similarity.py
@@ -33,6 +33,7 @@ from difflib import SequenceMatcher
 
 # Public API surface
 __all__ = [
+    "CC_PREFIX_RE",
     "ScoreResult",
     "ScoringConfig",
     "aggregate_scores",
@@ -47,6 +48,14 @@ __all__ = [
     "score_subjects",
     "sequence_ratio",
 ]
+
+# Compiled conventional-commit prefix regex, shared across modules.
+# Matches types like "feat:", "Fix(scope):", "Build(deps)!:" etc.
+CC_PREFIX_RE = re.compile(
+    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
+    r"(?:\([^)]*\))?\s*!?\s*:\s*",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -197,6 +206,7 @@ def extract_dependency_package_from_subject(subject: str) -> str:
     Examples to consider (to be implemented):
     - "Bump requests from 2.31.0 to 2.32.0" -> "requests"
     - "chore: update org/tool from v1.2.3 to v1.2.4" -> "org/tool"
+    - "Build(deps): Bump org/tool from 1.0 to 2.0" -> "org/tool"
 
     Args:
         subject: The (possibly unnormalized) subject line.
@@ -205,15 +215,20 @@ def extract_dependency_package_from_subject(subject: str) -> str:
         Package identifier, or empty string if none could be extracted.
     """
     s = (subject or "").lower()
+    # Strip any conventional-commit prefix before matching
+    cc_match = CC_PREFIX_RE.match(s)
+    if cc_match:
+        s = s[cc_match.end() :]
+
     patterns = [
         # Full version with "from" clause
-        r"(?:chore.*?:\s*)?bump\s+([^\s]+)\s+from\s+",
-        r"(?:chore.*?:\s*)?update\s+([^\s]+)\s+from\s+",
-        r"(?:chore.*?:\s*)?upgrade\s+([^\s]+)\s+from\s+",
+        r"bump\s+([^\s]+)\s+from\s+",
+        r"update\s+([^\s]+)\s+from\s+",
+        r"upgrade\s+([^\s]+)\s+from\s+",
         # Truncated version without "from" clause (for Gerrit subjects)
-        r"(?:chore.*?:\s*)?bump\s+([^\s]+)\s*$",
-        r"(?:chore.*?:\s*)?update\s+([^\s]+)\s*$",
-        r"(?:chore.*?:\s*)?upgrade\s+([^\s]+)\s*$",
+        r"bump\s+([^\s]+)\s*$",
+        r"update\s+([^\s]+)\s*$",
+        r"upgrade\s+([^\s]+)\s*$",
     ]
     for pat in patterns:
         m = re.search(pat, s)

--- a/tests/test_clean_squash_title.py
+++ b/tests/test_clean_squash_title.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 The Linux Foundation
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
 
 """Tests for _clean_squash_title_line (issue #187).
 

--- a/tests/test_clean_squash_title.py
+++ b/tests/test_clean_squash_title.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for _clean_squash_title_line (issue #187).
+
+The module-level helper in core.py handles markdown removal, separator
+splitting, and length truncation for squashed commit titles.  The bug
+reported in #187 caused conventional commit prefixes like
+``Build(deps):`` to be treated as sentence break-points, truncating
+the entire description when the title exceeded 100 characters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from github2gerrit.core import _clean_squash_title_line
+
+
+# -------------------------------------------------------------------
+# Issue #187: conventional commit prefix must survive truncation
+# -------------------------------------------------------------------
+
+
+class TestConventionalPrefixPreservation:
+    """Titles with a CC prefix must not be split on the prefix colon."""
+
+    def test_long_build_deps_title_preserved(self) -> None:
+        """Exact scenario from issue #187."""
+        title = (
+            "Build(deps): Bump "
+            "lfit/releng-reusable-workflows/"
+            ".github/workflows/"
+            "gerrit-required-info-yaml-verify.yaml "
+            "from 0.2.28 to 0.2.31"
+        )
+        result = _clean_squash_title_line(title)
+        # Must NOT be truncated to just "Build(deps):" (the old bug)
+        assert result != "Build(deps):"
+        # CC titles with long paths pass through in full — the length
+        # is inherent to the structured subject, not body leakage.
+        assert result == title
+
+    def test_long_chore_deps_title_preserved(self) -> None:
+        """Long chore(deps) title must keep content after prefix."""
+        title = (
+            "chore(deps): bump "
+            "very-long-org/very-long-repo-name/"
+            "some-deeply-nested-package-name "
+            "from 1.0.0 to 2.0.0 in the production group"
+        )
+        result = _clean_squash_title_line(title)
+        # Full title preserved — no word-boundary fallback for CC
+        assert result == title
+
+    def test_long_fix_scope_title_preserved(self) -> None:
+        """Long fix(scope) title must not truncate at prefix colon."""
+        title = (
+            "Fix(security): resolve critical vulnerability in "
+            "authentication module that allows bypass of "
+            "multi-factor authentication checks for admin users"
+        )
+        result = _clean_squash_title_line(title)
+        # No break-points in the content after the prefix, so the
+        # full CC title passes through unchanged.
+        assert result == title
+
+    def test_long_feat_breaking_title_preserved(self) -> None:
+        """Breaking change indicator must be preserved."""
+        title = (
+            "Feat!: redesign the entire authentication subsystem "
+            "to support OAuth2 and SAML providers alongside "
+            "existing LDAP integration for enterprise customers"
+        )
+        result = _clean_squash_title_line(title)
+        # Full CC title preserved (no content break-points)
+        assert result == title
+
+    def test_second_colon_used_as_break_point(self) -> None:
+        """A second ': ' after the prefix IS a valid break-point."""
+        title = (
+            "Chore(deps): update authentication module"
+            ": migrate legacy session handling to modern "
+            "token-based approach with enhanced security"
+        )
+        result = _clean_squash_title_line(title)
+        # Should break at the second ": " (after "module"),
+        # which IS in the content region, not the prefix.
+        assert result == "Chore(deps): update authentication module:"
+
+
+# -------------------------------------------------------------------
+# Underscore preservation (secondary fix in #187)
+# -------------------------------------------------------------------
+
+
+class TestUnderscorePreservation:
+    """Underscores in package/path names must not be stripped."""
+
+    def test_underscore_in_package_name(self) -> None:
+        """Package names with underscores must survive cleaning."""
+        title = "Bump my_org/setup_python from 1.0 to 2.0"
+        result = _clean_squash_title_line(title)
+        assert "my_org/setup_python" in result
+
+    def test_underscore_in_path(self) -> None:
+        """Filesystem paths with underscores must survive."""
+        title = (
+            "Update .github/workflows/my_custom_workflow.yml from 1.0 to 2.0"
+        )
+        result = _clean_squash_title_line(title)
+        assert "my_custom_workflow" in result
+
+    def test_asterisk_still_removed(self) -> None:
+        """Markdown bold asterisks should still be removed."""
+        title = "Bump **important** package from 1.0 to 2.0"
+        result = _clean_squash_title_line(title)
+        assert "**" not in result
+        assert "important" in result
+
+    def test_backtick_still_removed(self) -> None:
+        """Markdown code backticks should still be removed."""
+        title = "Bump `some-package` from 1.0 to 2.0"
+        result = _clean_squash_title_line(title)
+        assert "`" not in result
+        assert "some-package" in result
+
+
+# -------------------------------------------------------------------
+# Markdown link removal
+# -------------------------------------------------------------------
+
+
+class TestMarkdownLinkRemoval:
+    """Markdown links should be replaced with their display text."""
+
+    def test_markdown_link_replaced(self) -> None:
+        """Standard markdown link."""
+        title = "[package](https://example.com) update from 1.0 to 2.0"
+        result = _clean_squash_title_line(title)
+        assert "package" in result
+        assert "https://example.com" not in result
+        assert "[" not in result
+
+
+# -------------------------------------------------------------------
+# Trailing ellipsis removal
+# -------------------------------------------------------------------
+
+
+class TestEllipsisRemoval:
+    """Trailing ellipsis (and everything after) should be stripped."""
+
+    def test_trailing_ellipsis_removed(self) -> None:
+        """Three dots at the end."""
+        title = "Bump some-package from 1.0 to..."
+        result = _clean_squash_title_line(title)
+        assert "..." not in result
+        assert result.startswith("Bump some-package from 1.0")
+
+    def test_ellipsis_with_trailing_content(self) -> None:
+        """Ellipsis followed by extra content."""
+        title = "Bump some-package from 1.0 to... (truncated)"
+        result = _clean_squash_title_line(title)
+        assert "..." not in result
+        assert "truncated" not in result
+
+
+# -------------------------------------------------------------------
+# Separator splitting
+# -------------------------------------------------------------------
+
+
+class TestSeparatorSplitting:
+    """Titles with body-leak separators should be split correctly."""
+
+    def test_bumps_separator(self) -> None:
+        """'. Bumps ' separator splits correctly."""
+        title = "Update deps. Bumps requests from 2.31 to 2.32"
+        result = _clean_squash_title_line(title)
+        assert result == "Update deps"
+
+    def test_space_bumps_separator(self) -> None:
+        """' Bumps ' separator splits correctly."""
+        title = "Update deps Bumps requests from 2.31 to 2.32"
+        result = _clean_squash_title_line(title)
+        assert result == "Update deps"
+
+    def test_dot_dash_separator(self) -> None:
+        """'. - ' separator splits correctly."""
+        title = "Update package. - This is the body content"
+        result = _clean_squash_title_line(title)
+        assert result == "Update package"
+
+    def test_dash_separator(self) -> None:
+        """' - ' separator splits correctly."""
+        title = "Update package - This is extra context"
+        result = _clean_squash_title_line(title)
+        assert result == "Update package"
+
+
+# -------------------------------------------------------------------
+# Length truncation (non-CC titles)
+# -------------------------------------------------------------------
+
+
+class TestLengthTruncation:
+    """Titles exceeding 100 chars should be truncated sensibly."""
+
+    def test_short_title_not_truncated(self) -> None:
+        """Titles under 100 chars pass through unchanged."""
+        title = "Bump requests from 2.31.0 to 2.32.0"
+        result = _clean_squash_title_line(title)
+        assert result == title
+
+    def test_exactly_100_chars_not_truncated(self) -> None:
+        """Title at exactly 100 chars should not be truncated."""
+        title = "x" * 100
+        result = _clean_squash_title_line(title)
+        assert result == title
+
+    def test_long_title_truncated_at_period(self) -> None:
+        """Period break-point used for non-CC long titles."""
+        title = (
+            "This is a long sentence that describes the change. "
+            "And this is extra content that pushes it well "
+            "over the hundred character limit for subjects"
+        )
+        result = _clean_squash_title_line(title)
+        assert result == "This is a long sentence that describes the change."
+
+    def test_long_title_truncated_at_words(self) -> None:
+        """Fallback to word-boundary truncation when no break-points."""
+        # No break-point characters — just a long string of words
+        title = " ".join(["word"] * 30)  # 149 chars
+        result = _clean_squash_title_line(title)
+        assert len(result) <= 100
+        # Should not cut mid-word
+        assert result.endswith("word")
+
+    def test_non_cc_colon_break_point_still_works(self) -> None:
+        """Colon break-point works for non-CC titles (no CC prefix)."""
+        title = (
+            "This is a long title describing something important"
+            ": and then continues with even more detail "
+            "that pushes it well beyond the limit"
+        )
+        result = _clean_squash_title_line(title)
+        assert result == "This is a long title describing something important:"
+
+
+# -------------------------------------------------------------------
+# Edge cases
+# -------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Boundary and degenerate inputs."""
+
+    def test_empty_string(self) -> None:
+        """Empty input returns empty output."""
+        assert _clean_squash_title_line("") == ""
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only input returns empty string."""
+        assert _clean_squash_title_line("   ") == ""
+
+    def test_just_cc_prefix(self) -> None:
+        """A bare CC prefix (no description) passes through."""
+        result = _clean_squash_title_line("chore:")
+        assert result == "chore:"
+
+    def test_short_cc_title(self) -> None:
+        """Short CC title under 100 chars is untouched."""
+        title = "fix(core): resolve null pointer in parser"
+        result = _clean_squash_title_line(title)
+        assert result == title
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "CI(workflow): update release pipeline and add new deployment stages for multi-region support across all environments",
+            "Build(deps): Bump org/repo/.github/workflows/very-long-workflow-name.yaml from 0.2.28 to 0.2.31",
+            "Refactor(auth): reorganize authentication middleware to support pluggable providers including OAuth2 SAML and LDAP",
+        ],
+    )
+    def test_various_cc_types_not_truncated_at_prefix(self, title: str) -> None:
+        """Various CC types must not lose content after the prefix."""
+        result = _clean_squash_title_line(title)
+        prefix_end = title.index(": ") + 2
+        prefix = title[:prefix_end].rstrip()
+        # The prefix must be intact
+        assert result.startswith(prefix)
+        # There must be content after the prefix
+        after_prefix = result[len(prefix) :].strip()
+        assert len(after_prefix) > 0, (
+            f"Content after prefix was lost: {result!r}"
+        )

--- a/tests/test_commit_normalization.py
+++ b/tests/test_commit_normalization.py
@@ -170,7 +170,7 @@ class TestCommitNormalizer:
         test_cases = [
             ("[text](url) some title", "text some title"),
             ("Title with trailing...", "title with trailing"),
-            ("Title with *bold* and _italic_", "title with bold and italic"),
+            ("Title with *bold* and _italic_", "title with bold and _italic_"),
         ]
 
         for original, expected in test_cases:

--- a/tests/test_dependency_supersession.py
+++ b/tests/test_dependency_supersession.py
@@ -169,6 +169,10 @@ class TestQueryOpenChangesByProject:
 # -------------------------------------------------------------------
 
 
+@patch(
+    "github2gerrit.gerrit_urls._discover_base_path_for_host",
+    new=lambda *_a, **_kw: "",
+)
 class TestAbandonSupersededDependencyChanges:
     """Tests for the post-push abandon sweep."""
 
@@ -673,6 +677,10 @@ class TestStrategy5Integration:
 # -------------------------------------------------------------------
 
 
+@patch(
+    "github2gerrit.gerrit_urls._discover_base_path_for_host",
+    new=lambda *_a, **_kw: "",
+)
 class TestRealWorldScenarios:
     """Scenarios taken directly from the issue report."""
 

--- a/tests/test_dependency_supersession.py
+++ b/tests/test_dependency_supersession.py
@@ -1,0 +1,768 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for dependency supersession logic (issue #188).
+
+Covers two mechanisms:
+
+1. **Strategy 5** in ``_find_existing_change_for_pr`` — reuse the
+   Change-Id of an existing open Gerrit change that bumps the same
+   dependency package (update-in-place).
+
+2. **Post-push abandon sweep**
+   (``abandon_superseded_dependency_changes``) — after pushing a new
+   change, abandon any remaining open Gerrit changes for the same
+   dependency (Option A fallback).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from github2gerrit.core import Orchestrator
+from github2gerrit.gerrit_pr_closer import abandon_superseded_dependency_changes
+from github2gerrit.gerrit_query import GerritChange
+from github2gerrit.gerrit_query import query_open_changes_by_project
+from github2gerrit.gitreview import GerritInfo
+from github2gerrit.models import GitHubContext
+from github2gerrit.similarity import extract_dependency_package_from_subject
+
+
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+
+
+def _gerrit_change(
+    *,
+    change_id: str = "Iaaaa000000000000000000000000000000000000",
+    number: str = "12345",
+    subject: str = "chore: bump requests from 2.31.0 to 2.32.0",
+    status: str = "NEW",
+    files: list[str] | None = None,
+    commit_message: str = (
+        "chore: bump requests from 2.31.0 to 2.32.0\n\n"
+        "GitHub-PR: https://github.com/org/repo/pull/42\n"
+        "Signed-off-by: Bot <bot@example.com>"
+    ),
+    topic: str | None = None,
+) -> GerritChange:
+    """Factory for ``GerritChange`` test fixtures."""
+    return GerritChange(
+        change_id=change_id,
+        number=number,
+        subject=subject,
+        status=status,
+        current_revision="deadbeef",
+        files=files or [],
+        commit_message=commit_message,
+        topic=topic,
+    )
+
+
+# -------------------------------------------------------------------
+# extract_dependency_package_from_subject — baseline
+# -------------------------------------------------------------------
+
+
+class TestPackageExtraction:
+    """Verify that the package extractor works for titles we rely on."""
+
+    def test_simple_bump(self) -> None:
+        """Standard Dependabot title."""
+
+        pkg = extract_dependency_package_from_subject(
+            "Bump requests from 2.31.0 to 2.32.0"
+        )
+        assert pkg == "requests"
+
+    def test_scoped_package(self) -> None:
+        """Org-scoped package name."""
+
+        pkg = extract_dependency_package_from_subject(
+            "chore: bump @types/react from 18.2.0 to 18.3.0"
+        )
+        assert pkg == "@types/react"
+
+    def test_github_action_path(self) -> None:
+        """Long GitHub Actions workflow path."""
+
+        pkg = extract_dependency_package_from_subject(
+            "chore: bump lfreleng-actions/github2gerrit-action "
+            "from 1.0.8 to 1.2.0"
+        )
+        assert pkg == "lfreleng-actions/github2gerrit-action"
+
+    def test_non_dependency_title(self) -> None:
+        """Non-dependency title returns empty string."""
+
+        pkg = extract_dependency_package_from_subject("feat: add login page")
+        assert pkg == ""
+
+    def test_build_deps_prefix(self) -> None:
+        """Build(deps) prefix should be handled (CC broadening)."""
+
+        pkg = extract_dependency_package_from_subject(
+            "Build(deps): Bump lfit/releng-reusable-workflows "
+            "from 0.2.28 to 0.2.31"
+        )
+        assert pkg == "lfit/releng-reusable-workflows"
+
+    def test_fix_deps_prefix(self) -> None:
+        """Fix(deps) prefix should be handled."""
+
+        pkg = extract_dependency_package_from_subject(
+            "Fix(deps): update lodash from 4.17.20 to 4.17.21"
+        )
+        assert pkg == "lodash"
+
+
+# -------------------------------------------------------------------
+# query_open_changes_by_project
+# -------------------------------------------------------------------
+
+
+class TestQueryOpenChangesByProject:
+    """Unit tests for the new Gerrit query helper."""
+
+    def test_returns_changes_on_success(self) -> None:
+        """Should delegate to pagination helper and return results."""
+
+        fake_client = MagicMock()
+        fake_client.get.return_value = [
+            {
+                "change_id": "I111",
+                "_number": 100,
+                "subject": "chore: bump pkg from 1 to 2",
+                "status": "NEW",
+                "current_revision": "abc",
+                "revisions": {
+                    "abc": {
+                        "files": {},
+                        "commit": {"message": ""},
+                    }
+                },
+            },
+        ]
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", max_results=50
+        )
+        assert len(result) == 1
+        assert result[0].change_id == "I111"
+
+    def test_returns_empty_on_error(self) -> None:
+        """Should return empty list on REST error."""
+
+        fake_client = MagicMock()
+        fake_client.get.side_effect = RuntimeError("connection refused")
+
+        result = query_open_changes_by_project(fake_client, "org/repo")
+        assert result == []
+
+
+# -------------------------------------------------------------------
+# abandon_superseded_dependency_changes
+# -------------------------------------------------------------------
+
+
+class TestAbandonSupersededDependencyChanges:
+    """Tests for the post-push abandon sweep."""
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_abandons_matching_changes(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """Should abandon open changes bumping the same dependency."""
+
+        old_change = _gerrit_change(
+            change_id="Iold0000000000000000000000000000000000000",
+            number="100",
+            subject="chore: bump requests from 2.31.0 to 2.31.5",
+        )
+        unrelated_change = _gerrit_change(
+            change_id="Iunrelated00000000000000000000000000000",
+            number="200",
+            subject="feat: add logging",
+        )
+        mock_query.return_value = [old_change, unrelated_change]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=["Inew0000000000000000000000000000000000000"],
+        )
+
+        assert result == ["100"]
+        fake_client.post.assert_called_once()
+        call_args = fake_client.post.call_args
+        assert "/changes/100/abandon" in call_args[0][0]
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_skips_excluded_change_ids(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """Must not abandon the change we just pushed."""
+
+        our_change = _gerrit_change(
+            change_id="Iours000000000000000000000000000000000000",
+            number="300",
+            subject="chore: bump requests from 2.31.0 to 2.32.0",
+        )
+        mock_query.return_value = [our_change]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=["Iours000000000000000000000000000000000000"],
+        )
+
+        assert result == []
+        fake_client.post.assert_not_called()
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_no_action_for_different_packages(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """Changes for different packages must not be abandoned."""
+
+        other_pkg = _gerrit_change(
+            change_id="Iother00000000000000000000000000000000000",
+            number="400",
+            subject="chore: bump flask from 2.0 to 3.0",
+        )
+        mock_query.return_value = [other_pkg]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+        )
+
+        assert result == []
+        fake_client.post.assert_not_called()
+
+    def test_non_dependency_subject_returns_empty(self) -> None:
+        """Non-dependency subjects should short-circuit."""
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="feat: add login page",
+            exclude_change_ids=[],
+        )
+        assert result == []
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_dry_run_does_not_abandon(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """Dry-run mode should report but not POST to Gerrit."""
+
+        old_change = _gerrit_change(
+            change_id="Iold0000000000000000000000000000000000000",
+            number="500",
+            subject="chore: bump requests from 2.31.0 to 2.31.5",
+        )
+        mock_query.return_value = [old_change]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+            dry_run=True,
+        )
+
+        assert result == ["500"]
+        fake_client.post.assert_not_called()
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_abandon_multiple_stale_changes(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """Multiple stale changes for the same dep should all be abandoned."""
+
+        stale1 = _gerrit_change(
+            change_id="Istale1000000000000000000000000000000000",
+            number="601",
+            subject="chore: bump requests from 2.31.0 to 2.31.1",
+        )
+        stale2 = _gerrit_change(
+            change_id="Istale2000000000000000000000000000000000",
+            number="602",
+            subject="chore: bump requests from 2.31.0 to 2.31.5",
+        )
+        mock_query.return_value = [stale1, stale2]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+        )
+
+        assert sorted(result) == ["601", "602"]
+        assert fake_client.post.call_count == 2
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_abandon_failure_is_non_fatal(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """A failed abandon should not crash the sweep."""
+
+        stale = _gerrit_change(
+            change_id="Istale0000000000000000000000000000000000",
+            number="700",
+            subject="chore: bump requests from 2.31.0 to 2.31.1",
+        )
+        mock_query.return_value = [stale]
+
+        fake_client = MagicMock()
+        fake_client.post.side_effect = RuntimeError("403 forbidden")
+        mock_build_client.return_value = fake_client
+
+        # Should not raise
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+        )
+        assert result == []
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_github_actions_workflow_bump(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """GitHub Actions workflow bumps should match by action name."""
+
+        old_action = _gerrit_change(
+            change_id="Iaction000000000000000000000000000000000",
+            number="800",
+            subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.0.9"
+            ),
+        )
+        mock_query.return_value = [old_action]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.2.0"
+            ),
+            exclude_change_ids=[],
+        )
+
+        assert result == ["800"]
+        fake_client.post.assert_called_once()
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_rest_client_failure_is_non_fatal(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """REST client construction failure should not crash."""
+
+        mock_build_client.side_effect = RuntimeError("cannot connect")
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+        )
+        assert result == []
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_passes_target_branch_to_query(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """target_branch should be forwarded to the Gerrit query."""
+
+        mock_query.return_value = []
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        abandon_superseded_dependency_changes(
+            gerrit_server="gerrit.example.org",
+            gerrit_project="org/repo",
+            current_subject="chore: bump requests from 2.31.0 to 2.32.0",
+            exclude_change_ids=[],
+            target_branch="main",
+        )
+
+        mock_query.assert_called_once_with(
+            fake_client,
+            "org/repo",
+            branch="main",
+            max_results=200,
+        )
+
+
+# -------------------------------------------------------------------
+# Strategy 5 integration in _find_existing_change_for_pr
+# -------------------------------------------------------------------
+
+
+@dataclass
+class _FakeGitHubUser:
+    """Minimal mock of a GitHub user object."""
+
+    login: str = "dependabot[bot]"
+
+
+@dataclass
+class _FakeGitHubIssue:
+    """Minimal mock of a GitHub issue (for comments)."""
+
+    def get_comments(self) -> list[Any]:
+        """Return empty comment list."""
+        return []
+
+
+@dataclass
+class _FakePullRequest:
+    """Minimal mock of a GitHub PR object."""
+
+    number: int = 42
+    title: str = "Bump requests from 2.31.0 to 2.32.0"
+    state: str = "open"
+    user: _FakeGitHubUser | None = None
+
+    def as_issue(self) -> _FakeGitHubIssue:
+        """Return fake issue for comment iteration."""
+        return _FakeGitHubIssue()
+
+
+class TestStrategy5Integration:
+    """Test that Strategy 5 is reached and works in the discovery cascade."""
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_strategy5_finds_matching_change(
+        self,
+        mock_query_open: MagicMock,
+        mock_gerrit_client: MagicMock,
+        mock_get_pull: MagicMock,
+        mock_get_repo: MagicMock,
+        mock_build_client: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Strategy 5 should return Change-Id when package matches."""
+
+        # Set up GitHub mocks — strategies 1-4 should all fail
+        mock_get_pull.return_value = _FakePullRequest(
+            number=42,
+            title="Bump requests from 2.31.0 to 2.32.0",
+            user=_FakeGitHubUser(),
+        )
+        mock_get_repo.return_value = MagicMock()
+
+        # Strategy 1 (topic) will fail — no changes for this topic
+        # Strategy 2/3 (hash/trailer) will fail — no matching hash
+        # Strategy 4 (mapping comments) will fail — no comments
+        # Mock the Gerrit REST client to return empty for topic query
+        fake_gerrit = MagicMock()
+        fake_gerrit.get.return_value = []
+        mock_gerrit_client.return_value = fake_gerrit
+
+        # Strategy 5 — return an open change bumping the same package
+        existing_change = _gerrit_change(
+            change_id="Iexist00000000000000000000000000000000000",
+            number="999",
+            subject="chore: bump requests from 2.31.0 to 2.31.5",
+        )
+        mock_query_open.return_value = [existing_change]
+
+        # Build orchestrator and context
+        orch = Orchestrator(workspace=tmp_path)
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="1",
+            sha="abc123",
+            base_ref="main",
+            head_ref="dependabot/pip/requests-2.32.0",
+            pr_number=42,
+        )
+        gerrit = GerritInfo(
+            host="gerrit.example.org",
+            port=29418,
+            project="owner/repo",
+        )
+
+        result = orch._find_existing_change_for_pr(gh, gerrit)
+        assert result == ["Iexist00000000000000000000000000000000000"]
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_strategy5_skips_non_dependency_pr(
+        self,
+        mock_query_open: MagicMock,
+        mock_gerrit_client: MagicMock,
+        mock_get_pull: MagicMock,
+        mock_get_repo: MagicMock,
+        mock_build_client: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Strategy 5 should be skipped for non-dependency PRs."""
+
+        mock_get_pull.return_value = _FakePullRequest(
+            number=42,
+            title="feat: add user dashboard",
+            user=_FakeGitHubUser(login="human-dev"),
+        )
+        mock_get_repo.return_value = MagicMock()
+
+        fake_gerrit = MagicMock()
+        fake_gerrit.get.return_value = []
+        mock_gerrit_client.return_value = fake_gerrit
+
+        # Should never be called since package extraction fails
+        mock_query_open.return_value = []
+
+        orch = Orchestrator(workspace=tmp_path)
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="1",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature/dashboard",
+            pr_number=42,
+        )
+        gerrit = GerritInfo(
+            host="gerrit.example.org",
+            port=29418,
+            project="owner/repo",
+        )
+
+        result = orch._find_existing_change_for_pr(gh, gerrit)
+        assert result == []
+
+    @patch("github2gerrit.core.build_client")
+    @patch("github2gerrit.core.get_repo_from_env")
+    @patch("github2gerrit.core.get_pull")
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_strategy5_no_match_for_different_package(
+        self,
+        mock_query_open: MagicMock,
+        mock_gerrit_client: MagicMock,
+        mock_get_pull: MagicMock,
+        mock_get_repo: MagicMock,
+        mock_build_client: MagicMock,
+        tmp_path: Any,
+    ) -> None:
+        """Strategy 5 should not match changes for different packages."""
+
+        mock_get_pull.return_value = _FakePullRequest(
+            number=42,
+            title="Bump requests from 2.31.0 to 2.32.0",
+            user=_FakeGitHubUser(),
+        )
+        mock_get_repo.return_value = MagicMock()
+
+        fake_gerrit = MagicMock()
+        fake_gerrit.get.return_value = []
+        mock_gerrit_client.return_value = fake_gerrit
+
+        # Open change for a DIFFERENT package
+        different_pkg = _gerrit_change(
+            change_id="Idiff000000000000000000000000000000000000",
+            number="888",
+            subject="chore: bump flask from 2.0 to 3.0",
+        )
+        mock_query_open.return_value = [different_pkg]
+
+        orch = Orchestrator(workspace=tmp_path)
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="1",
+            sha="abc123",
+            base_ref="main",
+            head_ref="dependabot/pip/requests-2.32.0",
+            pr_number=42,
+        )
+        gerrit = GerritInfo(
+            host="gerrit.example.org",
+            port=29418,
+            project="owner/repo",
+        )
+
+        result = orch._find_existing_change_for_pr(gh, gerrit)
+        assert result == []
+
+
+# -------------------------------------------------------------------
+# Real-world scenarios from issue #188
+# -------------------------------------------------------------------
+
+
+class TestRealWorldScenarios:
+    """Scenarios taken directly from the issue report."""
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_ovsdb_three_stale_changes(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """ovsdb scenario: three stale g2g-action bumps, newest wins."""
+
+        stale_109 = _gerrit_change(
+            change_id="I109000000000000000000000000000000000000",
+            number="121752",
+            subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.0.9"
+            ),
+        )
+        stale_110 = _gerrit_change(
+            change_id="I110000000000000000000000000000000000000",
+            number="121797",
+            subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.1.0"
+            ),
+        )
+        current_120 = _gerrit_change(
+            change_id="I120000000000000000000000000000000000000",
+            number="122030",
+            subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.2.0"
+            ),
+        )
+        mock_query.return_value = [stale_109, stale_110, current_120]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="git.opendaylight.org",
+            gerrit_project="ovsdb",
+            current_subject=(
+                "chore: bump lfreleng-actions/github2gerrit-action "
+                "from 1.0.8 to 1.2.0"
+            ),
+            exclude_change_ids=["I120000000000000000000000000000000000000"],
+        )
+
+        assert sorted(result) == ["121752", "121797"]
+        assert fake_client.post.call_count == 2
+
+    @patch("github2gerrit.gerrit_rest.build_client_for_host")
+    @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
+    def test_lispflowmapping_mixed_packages(
+        self,
+        mock_query: MagicMock,
+        mock_build_client: MagicMock,
+    ) -> None:
+        """lispflowmapping: two different packages, only same-pkg abandoned."""
+
+        stale_info_yaml = _gerrit_change(
+            change_id="Iyaml000000000000000000000000000000000000",
+            number="121811",
+            subject=("chore: bump info-yaml-verify from 0.2.28 to 0.2.29"),
+        )
+        stale_g2g = _gerrit_change(
+            change_id="Ig2g0000000000000000000000000000000000000",
+            number="121813",
+            subject=("chore: bump github2gerrit-action from 1.0.9 to 1.1.0"),
+        )
+        mock_query.return_value = [stale_info_yaml, stale_g2g]
+
+        fake_client = MagicMock()
+        mock_build_client.return_value = fake_client
+
+        # Pushing new info-yaml-verify bump should only abandon the
+        # old info-yaml-verify change, NOT the g2g-action change.
+        result = abandon_superseded_dependency_changes(
+            gerrit_server="git.opendaylight.org",
+            gerrit_project="lispflowmapping",
+            current_subject=(
+                "chore: bump info-yaml-verify from 0.2.28 to 0.2.31"
+            ),
+            exclude_change_ids=[],
+        )
+
+        assert result == ["121811"]
+        assert fake_client.post.call_count == 1
+        call_path = fake_client.post.call_args[0][0]
+        assert "121811" in call_path


### PR DESCRIPTION
## Summary

Five commits addressing issues #187, #188, CodeQL security alerts, and Copilot review feedback.

### Commit 1: Fix #187 — Preserve CC prefix in squash title

The `_clean_title_line` function inside `_prepare_squashed_commit` truncated long titles (>100 chars) by splitting on break-points including `": "`. For conventional commit titles like `Build(deps): Bump lfit/releng-reusable-workflows/...`, this split at the prefix separator, discarding the entire description and producing empty subjects on Gerrit (e.g. `Build(deps):` with no content).

**Changes:**
- Extract title-cleaning logic into a testable module-level helper (`_clean_squash_title_line`)
- Detect conventional commit prefixes and skip the prefix `": "` when searching for break-points
- For CC titles with no content break-point, skip word-boundary fallback (the length is inherent to the structured subject, not body leakage)
- Preserve underscores in package/path names by removing only asterisks and backticks from markdown formatting

### Commit 2: Fix #188 — Auto-supersede dependency Gerrit changes

When Dependabot creates a new PR superseding an older one for the same dependency, the old Gerrit change was never abandoned, leading to stale/orphaned changes.

Two complementary mechanisms handle this:

**Pre-push: Change-Id reuse (Strategy 5 in `_find_existing_change_for_pr`).**
When strategies 1–4 find no reusable Change-Id, extract the dependency package name from the PR title and query Gerrit for open bot-owned changes on the same branch that bump the same package. If a match is found, reuse the oldest matching Change-Id so the push creates a new patchset on the existing change instead of a duplicate. Candidates are validated to ensure they carry GitHub2Gerrit metadata (`GitHub-PR:` trailer) and are scoped by `owner:self` and `branch:` to avoid touching unrelated changes.

**Post-push: Supersession sweep (`abandon_superseded_dependency_changes`).**
After a successful push, query Gerrit for any remaining open bot-owned changes on the same branch that bump the same dependency package. If the pre-push reuse already updated the old change in place, no duplicates will exist. Otherwise (e.g. when the pre-push path was skipped or the query failed), this sweep catches and abandons stale changes with a descriptive message linking to the new change.

**New helper:** `query_open_changes_by_project()` in `gerrit_query.py` — queries open changes in a Gerrit project with pagination support, scoped to `owner:self` with optional branch filtering.

### Commit 3: Exclude tests from CodeQL analysis

Add CodeQL advanced configuration file (`.github/codeql.yml`) that excludes the `tests` directory from scanning. Test assertions checking parsed hostnames trigger false-positive incomplete URL substring sanitization alerts.

### Commit 4: Fix CodeQL security alerts in production code

**Clear-text logging of sensitive information** (`netrc.py`): Stop logging password environment variable names in credential discovery debug messages. Only log the username variable name, which is sufficient for diagnostics.

**Incomplete URL substring sanitization** (`pr_content_filter.py`): Anchor the Dependabot image proxy check with URL scheme prefix (`https://camo.githubusercontent.com/`) to prevent substring bypass attacks.

### Commit 5: Address Copilot review feedback

Fixes accumulated across multiple Copilot review cycles:

- **Test isolation**: Patch `_discover_base_path_for_host` at class level in test classes to prevent real HTTP probes during unit tests (empty `GERRIT_HTTP_BASE_PATH` env var is insufficient as it still triggers discovery)
- **Log message accuracy**: Fix misleading "fallback password" → "primary password" in `netrc.py` mixed-credentials log message
- **Robust exception handling**: Broaden `except (ValueError, TypeError)` to `except Exception` in `_build_gerrit_change_url()` and `cli.py` URL builder — URLs are only for logging and should not block abandon operations
- **Gerrit query injection prevention**: Add `_gerrit_quote()` helper to escape `\` and `"` in values interpolated into Gerrit query strings; applied to topic/project/branch values
- **Break-point boundary fix**: Extend candidate slice in `_clean_squash_title_line` by max break-point length so break-points starting just before position 100 are detected even when spanning across the boundary
- **Unified CC prefix regex**: `CC_PREFIX_RE` in `similarity.py` replaces divergent patterns in `core.py` and `similarity.py`
- **DRY URL construction**: Extracted `_build_gerrit_change_url()` helper in `gerrit_pr_closer.py` to replace 3 copy-pasted try/except blocks
- **Direct field access**: Replaced redundant `getattr()` on `GerritChange` dataclass attributes
- **None guard**: `_clean_squash_title_line` handles `None`/empty input with `str | None` type signature
- **Emoji removal**: New log messages use plain text for portability
- **Copyright year**: Fixed to 2026 in new test files
- **Test imports**: Moved function-level imports to module level in test files
- **`CommitNormalizer._clean_title()`**: Fixed underscore stripping (same bug as #187)

## Test Coverage

- 28 new tests for #187 (`test_clean_squash_title.py`)
- 23 new tests for #188 (`test_dependency_supersession.py`)
- Full suite: all tests pass, 69.4% coverage (above 65% threshold)

## Related Issues

- Closes #187
- Ref #188
- Ref #181 (subset of #188)