### PR TITLE
Fix(coverage): Use package name in coverage source list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ disallow_untyped_calls = false
 
 [tool.coverage.run]
 branch = true
-source = ["src/github2gerrit"]
+source = ["github2gerrit"]
 omit = [
   "tests/*",
   "src/github2gerrit/gerrit_rest.py",


### PR DESCRIPTION
## Summary

Change `[tool.coverage.run] source` from `"src/github2gerrit"` (a
filesystem path) to `"github2gerrit"` (the import/package name).

## Background

coverage.py treats `source` entries that contain a path separator as
**path filters**, and entries without one as **package names**. Under
`lfreleng-actions/python-test-action` v1.1.x the project is installed
non-editably into `.venv/lib/pythonX.Y/site-packages/github2gerrit/`.
A path filter of `src/github2gerrit` never matches that installed
location, so coverage reports 0% with a "No data was collected"
warning.

Using the import name `github2gerrit` lets coverage.py instrument the
package wherever it is imported from (editable or non-editable).

## Why this is preventive

This project's `addopts` currently includes `--cov=github2gerrit`,
which overrides the `source` list at runtime — so coverage is being
measured correctly today. This PR fixes the latent misconfiguration
so the project remains correct if `addopts` changes or if the test
action's flag handling evolves.

## Related fixes

Same bug pattern fixed previously in:

- lfreleng-actions/markdown-table-fixer#129
- lfreleng-actions/gha-workflow-linter#196

## Out of scope

The existing `omit` entries that reference individual `src/github2gerrit/*.py`
files are intentionally left unchanged in this PR.