### PR TITLE
Fix: Declare click explicitly due to direct import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ dependencies = [
   # CLI framework (Typer)
   "typer>=0.20.1",
 
+  # Imported directly by the CLI (click.Group subclass for custom usage
+  # formatting; click.core.ParameterSource to detect explicit CLI flags)
+  # rather than only transitively via typer. Declared as a direct
+  # dependency so our import contract doesn't depend on typer's internal
+  # dependency choices.
+  "click>=8.1.7",
+
   # Rich formatting for CLI output
   "rich>=14.2.0",
 


### PR DESCRIPTION
- Added click>=8.1.7 as an explicit direct dependency in pyproject.toml
- Click is imported directly in cli.py but isn't declared in dependencies, it's been relying on a transitive install via typer. In some uvx/resolver scenarios that breaks.
- The fix follows the project pattern (explicit security-pinned deps with comments), declare click as a direct dependency.