### PR TITLE
Docs: add 'closed' event type to workflow usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ name: github2gerrit
 
 on:
   pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, closed]
   workflow_dispatch:
 
 permissions:
@@ -1146,7 +1146,7 @@ name: github2gerrit (advanced)
 
 on:
   pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, closed]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

The minimal and advanced workflow usage examples in the README were missing the `closed` event type in the `pull_request_target` trigger configuration:

```yaml
# Before (incorrect)
pull_request_target:
  types: [opened, reopened, edited, synchronize]
```

This caused adopters who copy-pasted the examples to miss the `CLEANUP_GERRIT` functionality. When a GitHub PR is closed (either merged directly on GitHub or superseded by Dependabot), the corresponding Gerrit change is never abandoned — leading to orphaned open changes accumulating on Gerrit.

## Root Cause

The Dependabot-specific example in the README already correctly included `closed`, but the primary usage examples (minimal + advanced) did not. This inconsistency led to **17 ODL project repos** deploying workflows without the `closed` trigger.

## Fix

Added `closed` to both usage examples:

```yaml
# After (correct)
pull_request_target:
  types: [opened, reopened, edited, synchronize, closed]
```

## Impact

The following ODL repos had orphaned Gerrit changes due to this issue and are being fixed separately (via `git review`):

- aaa, bgpcep, controller, daexim, gnmi, ietf, infrautils
- jsonrpc, l2switch, lispflowmapping, mdsal, netconf
- odlparent, openflowplugin, ovsdb, transportpce, yangtools

## How CLEANUP_GERRIT Works

When the `closed` event fires:
1. GitHub2Gerrit scans all open Gerrit changes in the project
2. Extracts the `GitHub-PR` trailer from each change's commit message
3. Checks if the corresponding GitHub PR is closed
4. Abandons the Gerrit change with an appropriate message

Without `closed` in the trigger, step 1 never happens on PR closure.

## Post-merge Action

After this fix and the ODL repo fixes are deployed, a one-time `workflow_dispatch` run (with `PR_NUMBER: 0`) on each affected repo will clean up existing orphaned Gerrit changes.

Reported by: Robert Varga
Example: https://git.opendaylight.org/gerrit/c/ovsdb/+/122552 (Gerrit open, GitHub PR closed)