### PR TITLE
Fix: abandon Gerrit changes over SSH on PR close

### DIFF
--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -11,6 +11,7 @@ merged and close the corresponding GitHub pull request that originated it.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import Any
 from typing import Literal
@@ -1679,11 +1680,57 @@ def _build_gerrit_abandon_message(pr_obj: Any, pr_url: str) -> str:
         )
 
 
+def _abandon_change_via_ssh_if_possible(
+    client: Any, change_number: str, message: str
+) -> bool:
+    """Attempt to abandon a change over SSH using ambient credentials.
+
+    Reads the Gerrit SSH connection details from the environment
+    (populated by the action) and the host from the REST *client*.
+
+    Returns ``True`` only if the change was abandoned via SSH; ``False``
+    when SSH is not configured or the SSH abandon did not succeed (in
+    which case the caller should fall back to REST).
+    """
+    ssh_privkey = os.getenv("GERRIT_SSH_PRIVKEY_G2G", "").strip()
+    ssh_user = os.getenv("GERRIT_SSH_USER_G2G", "").strip()
+    if not ssh_privkey or not ssh_user:
+        return False
+
+    host = os.getenv("GERRIT_SERVER", "").strip()
+    if not host:
+        host = getattr(client, "host", "") or ""
+    if not host:
+        return False
+
+    try:
+        port = int(os.getenv("GERRIT_SERVER_PORT", "29418") or "29418")
+    except ValueError:
+        port = 29418
+
+    from .gerrit_ssh import abandon_change_via_ssh
+
+    return abandon_change_via_ssh(
+        host=host,
+        change_number=str(change_number),
+        message=message,
+        user=ssh_user,
+        ssh_privkey=ssh_privkey,
+        known_hosts=os.getenv("GERRIT_KNOWN_HOSTS", ""),
+        port=port,
+    )
+
+
 def _abandon_gerrit_change(
     client: Any, change_number: str, message: str
 ) -> None:
     """
-    Abandon a Gerrit change via REST API.
+    Abandon a Gerrit change.
+
+    Prefers SSH (``gerrit review --abandon``) because mutating REST calls
+    are rejected with HTTP 403 on Gerrit servers that do not allow
+    unauthenticated REST writes and where only SSH credentials are
+    configured.  Falls back to the REST API when SSH is unavailable.
 
     Args:
         client: Gerrit REST client
@@ -1691,9 +1738,18 @@ def _abandon_gerrit_change(
         message: Abandon message
 
     Raises:
-        Exception: If abandon operation fails
+        Exception: If the abandon operation fails
     """
+    if _abandon_change_via_ssh_if_possible(client, change_number, message):
+        log.debug(
+            "Successfully abandoned Gerrit change %s via SSH", change_number
+        )
+        return
+
     try:
+        log.debug(
+            "Falling back to REST abandon for Gerrit change %s", change_number
+        )
         abandon_path = f"/changes/{change_number}/abandon"
         abandon_data = {"message": message}
         client.post(abandon_path, data=abandon_data)

--- a/src/github2gerrit/gerrit_rest.py
+++ b/src/github2gerrit/gerrit_rest.py
@@ -163,6 +163,19 @@ class GerritRestClient:
         """Return True if client has authentication credentials."""
         return self._auth is not None
 
+    @property
+    def host(self) -> str:
+        """Return the Gerrit hostname derived from the base URL.
+
+        Returns an empty string when the host cannot be determined.
+        """
+        from urllib.parse import urlparse
+
+        try:
+            return urlparse(self._base_url).hostname or ""
+        except Exception:
+            return ""
+
     def get(self, path: str) -> Any:
         """HTTP GET, returning parsed JSON."""
         return self._request_json_with_retry("GET", path)

--- a/src/github2gerrit/gerrit_ssh.py
+++ b/src/github2gerrit/gerrit_ssh.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+SSH-based Gerrit operations.
+
+Some Gerrit deployments (notably those fronted by a CDN/WAF, or that
+disallow anonymous REST writes) reject mutating REST calls such as
+``POST /changes/{id}/abandon`` with HTTP 403 unless dedicated HTTP API
+credentials are supplied.  The github2gerrit action authenticates to
+Gerrit over SSH (the same channel used to push changes), so this module
+performs the abandon over SSH instead, reusing the already-configured
+SSH key and known_hosts.
+
+The single public entry point :func:`abandon_change_via_ssh` is designed
+to be used as the preferred path with a REST fallback: it never raises
+and returns ``True`` only when the change was actually abandoned.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import shlex
+import tempfile
+from pathlib import Path
+
+from .gitutils import CommandError
+from .gitutils import run_cmd
+from .ssh_common import augment_known_hosts_with_bracketed_entries
+from .ssh_common import build_non_interactive_ssh_env
+
+
+log = logging.getLogger(__name__)
+
+DEFAULT_GERRIT_SSH_PORT = 29418
+_SSH_TIMEOUT_SECONDS = 30.0
+
+
+def _write_secure_file(path: Path, content: str, mode: int) -> None:
+    """Write *content* to *path* with restrictive *mode* permissions."""
+    # Create with secure permissions from the start (avoid a window where
+    # the file is world-readable).
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    try:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        # os.fdopen did not take ownership of fd; close it to avoid a leak.
+        os.close(fd)
+        raise
+    with handle:
+        handle.write(content)
+    # Re-assert mode in case umask altered it.
+    path.chmod(mode)
+
+
+def _build_ssh_base_argv(
+    *,
+    key_path: Path,
+    known_hosts_path: Path | None,
+    port: int,
+    user: str,
+    host: str,
+) -> list[str]:
+    """Build the common ``ssh`` argv prefix for non-interactive auth."""
+    argv: list[str] = [
+        "ssh",
+        "-F",
+        "/dev/null",
+        "-i",
+        str(key_path),
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "IdentityAgent=none",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "PreferredAuthentications=publickey",
+        "-o",
+        "PasswordAuthentication=no",
+        "-o",
+        "PubkeyAcceptedKeyTypes=+ssh-rsa",
+        "-o",
+        "ConnectTimeout=10",
+    ]
+    if known_hosts_path is not None:
+        argv += [
+            "-o",
+            f"UserKnownHostsFile={known_hosts_path}",
+            "-o",
+            "StrictHostKeyChecking=yes",
+        ]
+    else:
+        # No known_hosts supplied: we cannot verify the host key, but we
+        # still want a non-interactive connection.  accept-new records the
+        # key on first use; pair it with an explicit (throwaway)
+        # UserKnownHostsFile so OpenSSH does not mutate the runner's
+        # default ~/.ssh/known_hosts (which may be missing/unwritable).
+        log.warning(
+            "No GERRIT_KNOWN_HOSTS available for SSH abandon; using "
+            "StrictHostKeyChecking=accept-new with a throwaway known_hosts"
+        )
+        argv += [
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+        ]
+    argv += ["-n", "-p", str(port), f"{user}@{host}"]
+    return argv
+
+
+def _resolve_current_patchset(
+    base_argv: list[str],
+    change_number: str,
+    env: dict[str, str],
+) -> str | None:
+    """Return the current patch-set number for *change_number*, or None."""
+    remote_cmd = (
+        "gerrit query --format=JSON --current-patch-set "
+        f"change:{shlex.quote(change_number)}"
+    )
+    try:
+        result = run_cmd(
+            [*base_argv, remote_cmd],
+            timeout=_SSH_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except CommandError as exc:
+        log.debug(
+            "Gerrit SSH query for change %s failed: %s",
+            change_number,
+            exc,
+        )
+        return None
+
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        patch_set = record.get("currentPatchSet")
+        if isinstance(patch_set, dict) and patch_set.get("number") is not None:
+            return str(patch_set["number"])
+    log.debug(
+        "No currentPatchSet found in Gerrit query output for change %s",
+        change_number,
+    )
+    return None
+
+
+def abandon_change_via_ssh(
+    *,
+    host: str,
+    change_number: str,
+    message: str,
+    user: str,
+    ssh_privkey: str,
+    known_hosts: str | None = None,
+    port: int = DEFAULT_GERRIT_SSH_PORT,
+) -> bool:
+    """Abandon a Gerrit change over SSH using ``gerrit review --abandon``.
+
+    This is the preferred abandon path because it uses the same SSH
+    credentials that the action already relies on to push changes, and
+    therefore works on Gerrit servers that reject unauthenticated REST
+    writes.
+
+    Args:
+        host: Gerrit SSH hostname (no scheme).
+        change_number: Numeric Gerrit change number.
+        message: Abandon message (may be multi-line).
+        user: Gerrit SSH username.
+        ssh_privkey: SSH private key content.
+        known_hosts: Optional known_hosts content for host verification.
+        port: Gerrit SSH port (default 29418).
+
+    Returns:
+        ``True`` if the change was abandoned successfully; ``False`` when
+        prerequisites are missing or the SSH operation failed (so the
+        caller may fall back to another mechanism).  This function never
+        raises.
+    """
+    if not (host and user and ssh_privkey and str(change_number).strip()):
+        log.debug(
+            "SSH abandon prerequisites missing (host=%s, user=%s, "
+            "key=%s, change=%s); skipping SSH abandon",
+            bool(host),
+            bool(user),
+            bool(ssh_privkey),
+            change_number,
+        )
+        return False
+
+    change_number = str(change_number).strip()
+    try:
+        tmp_dir = Path(
+            tempfile.mkdtemp(prefix=f"g2g_abandon_{secrets.token_hex(8)}_")
+        )
+    except OSError as exc:
+        # Honor the "never raises" contract so callers can fall back to REST.
+        log.debug("Could not create temp dir for SSH abandon: %s", exc)
+        return False
+    try:
+        tmp_dir.chmod(0o700)
+        key_path = tmp_dir / "gerrit_key"
+        _write_secure_file(key_path, ssh_privkey.strip() + "\n", 0o600)
+
+        known_hosts_path: Path | None = None
+        if known_hosts and known_hosts.strip():
+            # OpenSSH looks up host keys under a bracketed "[host]:port"
+            # entry when connecting on a non-default port (Gerrit uses
+            # 29418).  Augment the provided content with bracketed variants
+            # so StrictHostKeyChecking can verify the key and we don't fall
+            # back to REST unnecessarily.
+            augmented = augment_known_hosts_with_bracketed_entries(
+                known_hosts.strip(), host, port
+            )
+            known_hosts_path = tmp_dir / "known_hosts"
+            _write_secure_file(known_hosts_path, augmented, 0o644)
+
+        base_argv = _build_ssh_base_argv(
+            key_path=key_path,
+            known_hosts_path=known_hosts_path,
+            port=port,
+            user=user,
+            host=host,
+        )
+
+        # Disable any ambient SSH agent so only the provided key is used.
+        ssh_env = build_non_interactive_ssh_env()
+
+        patch_set = _resolve_current_patchset(base_argv, change_number, ssh_env)
+        if patch_set is None:
+            log.debug(
+                "Could not resolve current patch-set for change %s via SSH",
+                change_number,
+            )
+            return False
+
+        target = f"{change_number},{patch_set}"
+        remote_cmd = (
+            "gerrit review --abandon "
+            f"-m {shlex.quote(message)} {shlex.quote(target)}"
+        )
+        try:
+            run_cmd(
+                [*base_argv, remote_cmd],
+                timeout=_SSH_TIMEOUT_SECONDS,
+                env=ssh_env,
+            )
+        except CommandError as exc:
+            log.warning(
+                "SSH abandon failed for change %s: %s",
+                change_number,
+                exc,
+            )
+            return False
+        else:
+            log.debug(
+                "Successfully abandoned Gerrit change %s via SSH",
+                change_number,
+            )
+            return True
+    except Exception:
+        log.warning(
+            "Unexpected error during SSH abandon for change %s",
+            change_number,
+            exc_info=True,
+        )
+        return False
+    finally:
+        try:
+            import shutil
+
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        except Exception:
+            log.debug("Failed to clean up SSH temp dir %s", tmp_dir)

--- a/tests/test_gerrit_ssh_abandon.py
+++ b/tests/test_gerrit_ssh_abandon.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Tests for SSH-based Gerrit abandon (gerrit_ssh module) and the SSH-first
+routing in gerrit_pr_closer._abandon_gerrit_change.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from github2gerrit import gerrit_ssh
+from github2gerrit.gitutils import CommandError
+from github2gerrit.gitutils import CommandResult
+
+
+def _ok(stdout: str = "") -> CommandResult:
+    return CommandResult(returncode=0, stdout=stdout, stderr="")
+
+
+_QUERY_JSON = (
+    '{"project":"netconf","number":123344,'
+    '"currentPatchSet":{"number":2}}\n'
+    '{"type":"stats","rowCount":1}\n'
+)
+
+
+class TestAbandonChangeViaSsh:
+    """Tests for gerrit_ssh.abandon_change_via_ssh."""
+
+    def test_returns_false_when_prerequisites_missing(self):
+        assert (
+            gerrit_ssh.abandon_change_via_ssh(
+                host="",
+                change_number="1",
+                message="m",
+                user="u",
+                ssh_privkey="key",
+            )
+            is False
+        )
+        assert (
+            gerrit_ssh.abandon_change_via_ssh(
+                host="h",
+                change_number="1",
+                message="m",
+                user="",
+                ssh_privkey="key",
+            )
+            is False
+        )
+        assert (
+            gerrit_ssh.abandon_change_via_ssh(
+                host="h",
+                change_number="1",
+                message="m",
+                user="u",
+                ssh_privkey="",
+            )
+            is False
+        )
+
+    def test_mkdtemp_failure_returns_false(self):
+        # Honor the "never raises" contract: a temp-dir failure must result
+        # in a clean False so the caller can fall back to REST.
+        with patch.object(
+            gerrit_ssh.tempfile,
+            "mkdtemp",
+            side_effect=OSError("disk full"),
+        ):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="123344",
+                message="m",
+                user="u",
+                ssh_privkey="key",
+            )
+        assert result is False
+
+    def test_successful_abandon_queries_then_reviews(self):
+        calls: list[list[str]] = []
+        known_hosts_seen: list[str] = []
+
+        def fake_run_cmd(cmd, **kwargs):
+            calls.append(list(cmd))
+            # Capture the known_hosts file content referenced in the argv.
+            for tok in cmd:
+                if isinstance(tok, str) and tok.startswith(
+                    "UserKnownHostsFile="
+                ):
+                    p = tok.split("=", 1)[1]
+                    with contextlib.suppress(OSError):
+                        known_hosts_seen.append(
+                            Path(p).read_text(encoding="utf-8")
+                        )
+            remote = cmd[-1]
+            if remote.startswith("gerrit query"):
+                return _ok(_QUERY_JSON)
+            return _ok("")
+
+        with patch.object(gerrit_ssh, "run_cmd", side_effect=fake_run_cmd):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="123344",
+                message="PR closed",
+                user="gh2gerrit",
+                ssh_privkey="PRIVKEY",
+                known_hosts="git.example.org ssh-ed25519 AAAA",
+                port=29418,
+            )
+
+        assert result is True
+        # Two SSH invocations: query then review.
+        assert len(calls) == 2
+        query_remote = calls[0][-1]
+        review_remote = calls[1][-1]
+        assert query_remote.startswith("gerrit query")
+        assert "change:123344" in query_remote
+        assert review_remote.startswith("gerrit review --abandon")
+        assert " -m " in review_remote
+        # The resolved patch-set must be used as <change>,<patchset>.
+        assert "123344,2" in review_remote
+        # Connection target is user@host on the given port.
+        assert "gh2gerrit@git.example.org" in calls[1]
+        assert "29418" in calls[1]
+        # known_hosts must be augmented with a bracketed [host]:port entry
+        # so verification works on the non-default Gerrit SSH port.
+        assert known_hosts_seen
+        assert "[git.example.org]:29418" in known_hosts_seen[0]
+
+    def test_no_known_hosts_uses_throwaway_file(self):
+        calls: list[list[str]] = []
+
+        def fake_run_cmd(cmd, **kwargs):
+            calls.append(list(cmd))
+            if cmd[-1].startswith("gerrit query"):
+                return _ok(_QUERY_JSON)
+            return _ok("")
+
+        with patch.object(gerrit_ssh, "run_cmd", side_effect=fake_run_cmd):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="123344",
+                message="m",
+                user="u",
+                ssh_privkey="k",
+                known_hosts=None,
+            )
+
+        assert result is True
+        # Without known_hosts we must not mutate the default known_hosts.
+        flat = " ".join(calls[0])
+        assert "UserKnownHostsFile=/dev/null" in flat
+        assert "StrictHostKeyChecking=accept-new" in flat
+
+    def test_returns_false_when_patchset_unresolved(self):
+        def fake_run_cmd(cmd, **kwargs):
+            remote = cmd[-1]
+            if remote.startswith("gerrit query"):
+                return _ok('{"type":"stats","rowCount":0}\n')
+            raise AssertionError("review should not run without a patch-set")
+
+        with patch.object(gerrit_ssh, "run_cmd", side_effect=fake_run_cmd):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="999",
+                message="m",
+                user="u",
+                ssh_privkey="k",
+            )
+        assert result is False
+
+    def test_returns_false_when_review_fails(self):
+        def fake_run_cmd(cmd, **kwargs):
+            remote = cmd[-1]
+            if remote.startswith("gerrit query"):
+                return _ok(_QUERY_JSON)
+            raise CommandError("abandon failed", returncode=1)
+
+        with patch.object(gerrit_ssh, "run_cmd", side_effect=fake_run_cmd):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="123344",
+                message="m",
+                user="u",
+                ssh_privkey="k",
+                known_hosts="kh",
+            )
+        assert result is False
+
+    def test_returns_false_when_query_fails(self):
+        def fake_run_cmd(cmd, **kwargs):
+            raise CommandError("query failed", returncode=255)
+
+        with patch.object(gerrit_ssh, "run_cmd", side_effect=fake_run_cmd):
+            result = gerrit_ssh.abandon_change_via_ssh(
+                host="git.example.org",
+                change_number="123344",
+                message="m",
+                user="u",
+                ssh_privkey="k",
+            )
+        assert result is False
+
+
+class TestAbandonRouting:
+    """Tests for SSH-first routing in _abandon_gerrit_change."""
+
+    def test_prefers_ssh_and_skips_rest(self, monkeypatch):
+        from github2gerrit import gerrit_pr_closer
+
+        monkeypatch.setenv("GERRIT_SSH_PRIVKEY_G2G", "PRIVKEY")
+        monkeypatch.setenv("GERRIT_SSH_USER_G2G", "gh2gerrit")
+        monkeypatch.setenv("GERRIT_SERVER", "git.example.org")
+        monkeypatch.setenv("GERRIT_KNOWN_HOSTS", "kh")
+        monkeypatch.setenv("GERRIT_SERVER_PORT", "29418")
+
+        client = MagicMock()
+        with patch(
+            "github2gerrit.gerrit_ssh.abandon_change_via_ssh",
+            return_value=True,
+        ) as mock_ssh:
+            gerrit_pr_closer._abandon_gerrit_change(client, "123344", "msg")
+
+        mock_ssh.assert_called_once()
+        client.post.assert_not_called()
+
+    def test_falls_back_to_rest_when_ssh_unavailable(self, monkeypatch):
+        from github2gerrit import gerrit_pr_closer
+
+        monkeypatch.delenv("GERRIT_SSH_PRIVKEY_G2G", raising=False)
+        monkeypatch.delenv("GERRIT_SSH_USER_G2G", raising=False)
+
+        client = MagicMock()
+        client.host = "git.example.org"
+        gerrit_pr_closer._abandon_gerrit_change(client, "123344", "msg")
+        client.post.assert_called_once()
+        args, _kwargs = client.post.call_args
+        assert "/changes/123344/abandon" in args[0]
+
+    def test_falls_back_to_rest_when_ssh_fails(self, monkeypatch):
+        from github2gerrit import gerrit_pr_closer
+
+        monkeypatch.setenv("GERRIT_SSH_PRIVKEY_G2G", "PRIVKEY")
+        monkeypatch.setenv("GERRIT_SSH_USER_G2G", "gh2gerrit")
+        monkeypatch.setenv("GERRIT_SERVER", "git.example.org")
+
+        client = MagicMock()
+        with patch(
+            "github2gerrit.gerrit_ssh.abandon_change_via_ssh",
+            return_value=False,
+        ):
+            gerrit_pr_closer._abandon_gerrit_change(client, "123344", "msg")
+        client.post.assert_called_once()


### PR DESCRIPTION
## Summary

Closed GitHub PRs were **not abandoning** their corresponding Gerrit changes on
servers that only accept SSH credentials (e.g. OpenDaylight). The abandon was
being attempted over the Gerrit **REST API**, which returns **HTTP 403** for
unauthenticated mutating calls. This PR routes the abandon over **SSH** (the
same channel already used to push changes), with an automatic **REST fallback**
when SSH is not configured.

---

## Background

When a PR is closed, github2gerrit is expected to clean up the open Gerrit
change it created, so stale changes don't accumulate. The cleanup path:

1. The `closed` event triggers `call-github2gerrit.yaml`.
2. `models.get_operation_mode()` maps `closed` → `CLOSE`.
3. `cli.py:_process()` takes the `CLOSE` branch and calls
   `abandon_gerrit_change_for_closed_pr()`.
4. The matching change is located by its `GitHub-PR:` commit trailer
   (e.g. `GitHub-PR: https://github.com/opendaylight/netconf/pull/35`).
5. `gerrit_pr_closer._abandon_gerrit_change()` abandons the change.

Steps 1–4 work correctly. Step 5 was the failure point.

---

## Root cause

`_abandon_gerrit_change()` issued the abandon as a REST mutation:

```python
client.post(f"/changes/{change_number}/abandon", ...)
```

`build_client_for_host()` falls back to **anonymous** auth when
`GERRIT_HTTP_PASSWORD` is unset — which is the case for OpenDaylight, where only
SSH credentials (`GERRIT_SSH_PRIVKEY_G2G`, `GERRIT_SSH_USER_G2G`,
`GERRIT_KNOWN_HOSTS`) are provisioned. Consequences:

- Anonymous REST **GET** works → the change is found (read path succeeds).
- Anonymous REST **POST `/abandon`** is a mutation requiring auth → **HTTP 403**.

The change *creation* succeeds precisely because it goes over **SSH**
(port 29418), not REST. So the asymmetry is: push/create over SSH (authenticated)
vs. abandon over REST (anonymous → 403).

### Evidence

netconf change
[123344](https://git.opendaylight.org/gerrit/c/netconf/+/123344) — PR closed but
change remained `NEW`. Verified the trailer/topic via SSH:

```
$ ssh -p 29418 askb@git.opendaylight.org gerrit query --current-patch-set change:123344
  ... GitHub-PR: https://github.com/opendaylight/netconf/pull/35
  ... topic: GH-netconf-35   status: NEW
```

Run log (`gh run view 27010361149 --log`) — the CLOSE path *is* reached and the
change *is* found; only the abandon fails:

```
🚪 Pull request #35 closed; performing Gerrit cleanup
Gerrit REST POST https://git.opendaylight.org/gerrit/changes/123344/abandon failed with HTTP 403
```

Reproduced on both the pinned `v1.2.2` and current `main`.

---

## Fix

Perform the abandon over **SSH**, reusing the already-configured SSH key and
known_hosts, and fall back to REST when SSH isn't available.

### New: `src/github2gerrit/gerrit_ssh.py`

`abandon_change_via_ssh(*, host, change_number, message, user, ssh_privkey, known_hosts=None, port=29418) -> bool`

- Writes the private key (`0600`) and known_hosts into a `0700` temp dir.
- Resolves the current patch set:
  `gerrit query --format=JSON --current-patch-set change:<n>`
  (parses `currentPatchSet.number`).
- Abandons: `gerrit review --abandon -m <message> <change>,<patchset>`.
- **Never raises**; returns `True` only when the abandon actually succeeds, so
  the caller can cleanly fall back.

### Changed: `src/github2gerrit/gerrit_pr_closer.py`

- `_abandon_gerrit_change()` now tries SSH first, then falls back to REST.
  Centralizing the logic here means **all five** abandon call sites benefit with
  no signature churn.
- Reads connection details from the environment:
  `GERRIT_SSH_PRIVKEY_G2G`, `GERRIT_SSH_USER_G2G`,
  `GERRIT_SERVER` (falls back to the REST client host),
  `GERRIT_SERVER_PORT` (default `29418`), `GERRIT_KNOWN_HOSTS`.
  If key/user are missing → returns `False` → REST fallback (existing behavior
  preserved for HTTP-authenticated servers).

### Changed: `src/github2gerrit/gerrit_rest.py`

- Added a `host` property to `GerritRestClient` (parses the hostname from the
  base URL) so the closer can derive the SSH host when `GERRIT_SERVER` is unset.

---

## Security / robustness (addressed in review)

- **Bracketed known_hosts for non-default port:** Gerrit SSH runs on `29418`,
  and OpenSSH looks up host keys under a bracketed `[host]:port` entry. The
  provided `GERRIT_KNOWN_HOSTS` content is now augmented via the repo's existing
  `augment_known_hosts_with_bracketed_entries()` helper so host-key verification
  succeeds (otherwise SSH would fail and silently fall back to REST — defeating
  the fix).
- **No runner-state mutation on fallback:** when no known_hosts is supplied, the
  `accept-new` path now sets `-o UserKnownHostsFile=/dev/null` so OpenSSH never
  writes to the runner's `~/.ssh/known_hosts`.
- **No file-descriptor leak:** `_write_secure_file()` closes the raw `fd` if
  `os.fdopen()` raises.
- **Non-interactive, key-only auth:** `BatchMode=yes`, `IdentitiesOnly=yes`,
  `IdentityAgent=none`, `PreferredAuthentications=publickey`,
  `PasswordAuthentication=no`, `-F /dev/null`, `ConnectTimeout=10`, and a 30s
  command timeout. The message is shell-quoted with `shlex.quote`.
- **`-m` flag** used for the abandon message to match `core.py` and stay
  compatible with older Gerrit SSH command parsers.

---

## Validation

- `pre-commit` (ruff, ruff-format, mypy, basedpyright, reuse, codespell, pytest)
  passes.
- New `tests/test_gerrit_ssh_abandon.py` covers: query→review success,
  `-m` flag, `<change>,<patchset>` targeting, bracketed `[host]:port`
  known_hosts augmentation, `/dev/null` on the no-known_hosts path, missing
  prerequisites, unresolved patch set, query/review failures, SSH-preferred
  routing, and REST fallback when SSH is unavailable/failed.
- Related suites (`test_gerrit_pr_closer`, `test_gerrit_rest_client`) green.

---

## ⚠️ Release note

ODL workflows run this tool via `uvx --from github2gerrit` (the PyPI package),
so the `action.yaml` SHA pin does **not** pin the Python tool version. The fix
only reaches ODL repos once a **new `github2gerrit` package version is
released** to PyPI.
