### PR TITLE
Fix: surface Gerrit auth failures without noise

### DIFF
--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -410,9 +410,13 @@ class Orchestrator:
 
             # Check if client has authentication
             if not client.is_authenticated:
+                from .gerrit_rest import warn_gerrit_credentials_unavailable
+
+                warn_gerrit_credentials_unavailable()
                 log.debug(
-                    "Cannot update Gerrit change metadata: "
-                    "No credentials found (check .netrc or environment)"
+                    "Cannot update Gerrit change metadata for %s: "
+                    "no Gerrit REST credentials available",
+                    change_id,
                 )
                 return False
 

--- a/src/github2gerrit/external_api.py
+++ b/src/github2gerrit/external_api.py
@@ -380,12 +380,26 @@ def external_api_call(
                     reason = (
                         "final attempt" if is_final_attempt else "non-retryable"
                     )
-                    log_exception_conditionally(
-                        log,
+                    failure_msg = (
                         f"[{api_type.value}] {operation} failed ({reason}) "
                         f"after {attempt} attempt(s) in {duration:.2f}s: "
-                        f"{target}",
+                        f"{target}"
                     )
+                    # Authentication/authorization failures (Gerrit REST
+                    # 401/403) are surfaced once, closer to the request, as a
+                    # concise warning. Avoid emitting a duplicate error/
+                    # traceback for them here. Scope this strictly to Gerrit
+                    # REST: other API types (e.g. GitHub) may also expose a
+                    # ``.status`` attribute, and their auth/permission
+                    # failures must retain error-level visibility.
+                    is_gerrit_auth_failure = (
+                        api_type == ApiType.GERRIT_REST
+                        and getattr(exc, "status", None) in (401, 403)
+                    )
+                    if is_gerrit_auth_failure:
+                        log.debug(failure_msg)
+                    else:
+                        log_exception_conditionally(log, failure_msg)
                     _update_metrics(api_type, context, success=False, exc=exc)
                     raise
                 else:

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -1754,6 +1754,19 @@ def _abandon_gerrit_change(
         abandon_data = {"message": message}
         client.post(abandon_path, data=abandon_data)
         log.debug("Successfully abandoned Gerrit change %s", change_number)
+    except GerritRestError as exc:
+        if exc.is_auth_error:
+            # Expected when no Gerrit REST credentials are available; the
+            # REST layer already surfaced this once. Avoid a duplicate
+            # error-level traceback for an authentication failure.
+            log.debug(
+                "REST abandon for Gerrit change %s failed (HTTP %s)",
+                change_number,
+                exc.status,
+            )
+        else:
+            log.exception("Failed to abandon Gerrit change %s", change_number)
+        raise
     except Exception:
         log.exception("Failed to abandon Gerrit change %s", change_number)
         raise

--- a/src/github2gerrit/gerrit_query.py
+++ b/src/github2gerrit/gerrit_query.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import quote
 
 from .gerrit_rest import GerritRestClient
+from .gerrit_rest import warn_gerrit_credentials_unavailable
 
 
 log = logging.getLogger(__name__)
@@ -148,6 +149,20 @@ def query_open_changes_by_project(
     query = f'project:"{_gerrit_quote(project)}" status:open owner:self'
     if branch:
         query += f' branch:"{_gerrit_quote(branch)}"'
+
+    # The ``owner:self`` predicate requires an authenticated Gerrit
+    # session; an anonymous request is rejected with HTTP 403. Skip the
+    # query (warning once per run) instead of issuing a request that is
+    # guaranteed to fail and would otherwise emit error-level noise.
+    if not client.is_authenticated:
+        warn_gerrit_credentials_unavailable()
+        log.debug(
+            "Skipping owner:self query for project '%s': "
+            "no Gerrit REST credentials available",
+            project,
+        )
+        return []
+
     log.debug("Querying Gerrit for open changes: %s", query)
 
     try:

--- a/src/github2gerrit/gerrit_rest.py
+++ b/src/github2gerrit/gerrit_rest.py
@@ -46,6 +46,7 @@ from .gerrit_urls import create_gerrit_url_builder
 from .netrc import GerritCredentials
 from .netrc import resolve_gerrit_credentials
 from .utils import log_exception_conditionally
+from .utils import log_warning_once
 
 
 log = logging.getLogger("github2gerrit.gerrit_rest")
@@ -80,12 +81,79 @@ _TRANSIENT_ERR_SUBSTRINGS: Final[tuple[str, ...]] = (
     "gateway timeout",
 )
 
+# HTTP status codes that indicate an authentication/authorization problem
+# rather than a transient fault or a bug. These are expected when no
+# Gerrit REST credentials are available (or they are insufficient for the
+# requested operation), and are surfaced as concise, default-visible
+# warnings rather than error-level tracebacks.
+_AUTH_ERROR_STATUSES: Final[tuple[int, ...]] = (401, 403)
+
+# Shared dedup key so the "no Gerrit REST credentials" situation is
+# surfaced at most once per run, regardless of how many auth-gated
+# operations are affected.
+_CREDENTIALS_UNAVAILABLE_KEY: Final[str] = "gerrit_rest_credentials_unavailable"
+
+
+def _is_auth_status(status: int | None) -> bool:
+    """Return True if the HTTP status indicates an auth/authorization error."""
+    return status in _AUTH_ERROR_STATUSES
+
+
+def _extract_http_status(exc: BaseException) -> int | None:
+    """Best-effort extraction of an HTTP status code from an exception.
+
+    Handles both the urllib path (``urllib.error.HTTPError.code``) and the
+    pygerrit2/requests path (``HTTPError.response.status_code``).
+    """
+    code = getattr(exc, "code", None)
+    if isinstance(code, int):
+        return code
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status
+    return None
+
+
+def warn_gerrit_credentials_unavailable() -> None:
+    """Warn once per run that authenticated Gerrit REST is unavailable.
+
+    Call this from auth-gated code paths before skipping an operation that
+    requires Gerrit REST credentials. The warning is emitted at most once
+    per process to avoid log spam while still making the degraded behavior
+    visible at the default log level.
+    """
+    log_warning_once(
+        log,
+        _CREDENTIALS_UNAVAILABLE_KEY,
+        "Gerrit REST credentials are not available; authenticated Gerrit "
+        "REST operations are disabled. Fallback behavior may apply and "
+        "could degrade performance. Provide GERRIT_HTTP_USER and "
+        "GERRIT_HTTP_PASSWORD (or a .netrc entry) to enable authenticated "
+        "Gerrit REST access.",
+    )
+
 
 # Removed individual retry logic functions - now using centralized framework
 
 
 class GerritRestError(RuntimeError):
-    """Raised for non-retryable REST errors or exhausted retries."""
+    """Raised for non-retryable REST errors or exhausted retries.
+
+    Args:
+        status: HTTP status code associated with the failure, when known.
+            Used by callers to distinguish authentication/authorization
+            problems (401/403) from transient or unexpected errors.
+    """
+
+    def __init__(self, *args: object, status: int | None = None) -> None:
+        super().__init__(*args)
+        self.status = status
+
+    @property
+    def is_auth_error(self) -> bool:
+        """Return True if this error stems from an auth failure (401/403)."""
+        return _is_auth_status(self.status)
 
 
 @dataclass(frozen=True)
@@ -264,13 +332,38 @@ class GerritRestClient:
         except urllib.error.HTTPError as http_exc:
             status = getattr(http_exc, "code", None)
             msg = f"Gerrit REST {method} {url} failed with HTTP {status}"
-            log_exception_conditionally(log, msg)
-            raise GerritRestError(msg) from http_exc
+            self._log_request_failure(msg, status)
+            raise GerritRestError(msg, status=status) from http_exc
 
         except Exception as exc:
+            status = _extract_http_status(exc)
             msg = f"Gerrit REST {method} {url} failed: {exc}"
+            self._log_request_failure(msg, status)
+            raise GerritRestError(msg, status=status) from exc
+
+    @staticmethod
+    def _log_request_failure(msg: str, status: int | None) -> None:
+        """Log a failed REST request at an appropriate level.
+
+        Authentication/authorization failures (401/403) are expected when
+        credentials are missing or insufficient; they are surfaced as a
+        single concise warning per run rather than an error-level traceback,
+        since they are neither transient faults nor bugs. All other failures
+        retain the existing conditional error/traceback behavior.
+        """
+        if _is_auth_status(status):
+            log_warning_once(
+                log,
+                f"gerrit_rest_auth_{status}",
+                "Gerrit REST authentication failed (HTTP %s): the configured "
+                "credentials are missing or insufficient for this operation. "
+                "Fallback behavior may apply and could degrade performance. "
+                "Details: %s",
+                status,
+                msg,
+            )
+        else:
             log_exception_conditionally(log, msg)
-            raise GerritRestError(msg) from exc
 
     def __repr__(self) -> str:  # pragma: no cover - convenience
         masked = ""
@@ -385,4 +478,5 @@ __all__ = [
     "GerritRestClient",
     "GerritRestError",
     "build_client_for_host",
+    "warn_gerrit_credentials_unavailable",
 ]

--- a/src/github2gerrit/orchestrator/reconciliation.py
+++ b/src/github2gerrit/orchestrator/reconciliation.py
@@ -511,12 +511,24 @@ def _abandon_orphan_changes(
 
     from github2gerrit.gerrit_rest import GerritRestError
     from github2gerrit.gerrit_rest import build_client_for_host
+    from github2gerrit.gerrit_rest import warn_gerrit_credentials_unavailable
 
-    abandoned = []
+    abandoned: list[str] = []
     try:
         client = build_client_for_host(
             gerrit.host, timeout=10.0, max_attempts=3
         )
+
+        # Abandoning a change is a mutating REST call that requires
+        # authentication; without credentials every attempt would 403.
+        # Warn once and skip rather than emitting per-change errors.
+        if not client.is_authenticated:
+            warn_gerrit_credentials_unavailable()
+            log.debug(
+                "Skipping orphan-change abandon: "
+                "no Gerrit REST credentials available"
+            )
+            return abandoned
 
         for change_id in orphan_ids:
             try:
@@ -559,12 +571,24 @@ def _comment_orphan_changes(
 
     from github2gerrit.gerrit_rest import GerritRestError
     from github2gerrit.gerrit_rest import build_client_for_host
+    from github2gerrit.gerrit_rest import warn_gerrit_credentials_unavailable
 
-    commented = []
+    commented: list[str] = []
     try:
         client = build_client_for_host(
             gerrit.host, timeout=10.0, max_attempts=3
         )
+
+        # Posting a review comment is a mutating REST call that requires
+        # authentication; without credentials every attempt would 403.
+        # Warn once and skip rather than emitting per-change errors.
+        if not client.is_authenticated:
+            warn_gerrit_credentials_unavailable()
+            log.debug(
+                "Skipping orphan-change comment: "
+                "no Gerrit REST credentials available"
+            )
+            return commented
 
         for change_id in orphan_ids:
             try:

--- a/src/github2gerrit/utils.py
+++ b/src/github2gerrit/utils.py
@@ -10,6 +10,7 @@ and ensure consistent behavior.
 
 import logging
 import os
+import threading
 from typing import Any
 
 
@@ -90,6 +91,50 @@ def log_exception_conditionally(
         logger.exception(message, *args)
     else:
         logger.error(message, *args)
+
+
+_WARNED_ONCE_LOCK = threading.Lock()
+_WARNED_ONCE_KEYS: set[str] = set()
+
+
+def log_warning_once(
+    logger: logging.Logger, dedup_key: str, message: str, *args: Any
+) -> None:
+    """Emit a warning at most once per process for a given dedup key.
+
+    Useful for expected, recurring conditions (for example, an
+    authentication-gated operation that is skipped because no
+    credentials are available) where surfacing the situation once is
+    helpful but repeating it for every affected item would be noisy.
+
+    Thread-safe: PRs may be processed concurrently (see the
+    ``ThreadPoolExecutor`` in ``cli._process_bulk``), so the
+    check-and-record step is guarded by a lock to preserve the
+    warn-once guarantee. The warning itself is emitted outside the lock
+    to avoid holding it during logging I/O.
+
+    Args:
+        logger: Logger instance to use.
+        dedup_key: Stable key identifying the warning; subsequent calls
+            with the same key are suppressed.
+        message: Log message format string.
+        *args: Arguments for message formatting.
+    """
+    with _WARNED_ONCE_LOCK:
+        if dedup_key in _WARNED_ONCE_KEYS:
+            return
+        _WARNED_ONCE_KEYS.add(dedup_key)
+    logger.warning(message, *args)
+
+
+def reset_warning_once() -> None:
+    """Clear the warn-once dedup cache.
+
+    Primarily intended for tests that need to assert warn-once behavior
+    across independent cases within a single process.
+    """
+    with _WARNED_ONCE_LOCK:
+        _WARNED_ONCE_KEYS.clear()
 
 
 def append_github_output(outputs: dict[str, str]) -> None:

--- a/tests/test_dependency_supersession.py
+++ b/tests/test_dependency_supersession.py
@@ -163,6 +163,25 @@ class TestQueryOpenChangesByProject:
         result = query_open_changes_by_project(fake_client, "org/repo")
         assert result == []
 
+    def test_skips_when_unauthenticated(self) -> None:
+        """owner:self requires auth; skip (no request) when unauthenticated.
+
+        Without Gerrit REST credentials the ``owner:self`` query is
+        guaranteed to fail with HTTP 403, so the helper must short-circuit
+        and never issue the request, returning an empty list.
+        """
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+
+        result = query_open_changes_by_project(fake_client, "org/repo")
+
+        assert result == []
+        fake_client.get.assert_not_called()
+
 
 # -------------------------------------------------------------------
 # abandon_superseded_dependency_changes

--- a/tests/test_external_api_framework.py
+++ b/tests/test_external_api_framework.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import urllib.error
 from io import StringIO
 from pathlib import Path
@@ -120,6 +121,52 @@ def test_external_api_call_non_retryable_error() -> None:
     assert metrics.successful_calls == 0
     assert metrics.failed_calls == 1
     assert metrics.retry_attempts == 0  # No retries for non-transient errors
+
+
+def test_auth_failure_logging_scoped_to_gerrit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """401/403 log suppression must apply only to Gerrit REST.
+
+    Other API types (e.g. GitHub) can also expose a ``.status`` attribute,
+    so their auth/permission failures must retain error-level visibility;
+    only Gerrit REST auth failures are downgraded here (they are surfaced
+    once, as a concise warning, closer to the request).
+    """
+
+    class _StatusError(Exception):
+        def __init__(self, status: int) -> None:
+            super().__init__(f"HTTP {status}")
+            self.status = status
+
+    @external_api_call(
+        ApiType.GITHUB, "github_op", policy=RetryPolicy(max_attempts=1)
+    )
+    def github_forbidden() -> None:
+        raise _StatusError(403)
+
+    @external_api_call(
+        ApiType.GERRIT_REST, "gerrit_op", policy=RetryPolicy(max_attempts=1)
+    )
+    def gerrit_forbidden() -> None:
+        raise _StatusError(403)
+
+    reset_api_metrics(ApiType.GITHUB)
+    reset_api_metrics(ApiType.GERRIT_REST)
+
+    with caplog.at_level(logging.DEBUG, logger="github2gerrit.external_api"):
+        with pytest.raises(_StatusError):
+            github_forbidden()
+        with pytest.raises(_StatusError):
+            gerrit_forbidden()
+
+    error_records = [
+        rec for rec in caplog.records if rec.levelno == logging.ERROR
+    ]
+    # GitHub auth failure retains error-level visibility...
+    assert any("github_op" in rec.getMessage() for rec in error_records)
+    # ...while the Gerrit REST auth failure is not logged at error level here.
+    assert not any("gerrit_op" in rec.getMessage() for rec in error_records)
 
 
 def test_external_api_call_retry_exhaustion(

--- a/tests/test_gerrit_rest_client.py
+++ b/tests/test_gerrit_rest_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import logging
 import os
 import stat
 from collections.abc import Callable
@@ -289,3 +290,139 @@ def test_commit_msg_hook_integrity_success_and_executable(
     # Cleanup not strictly necessary, but keep tmp tidy
     with contextlib.suppress(OSError):
         os.remove(hook_path)
+
+
+def test_gerrit_rest_403_sets_auth_status_and_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 403 should produce an auth-tagged error and a single warning.
+
+    Authentication/authorization failures are expected when credentials
+    are missing or insufficient. They must be surfaced as a concise,
+    default-visible warning (not an error-level traceback), and the
+    resulting GerritRestError must carry the HTTP status so callers can
+    distinguish auth problems from transient faults.
+    """
+    from github2gerrit.utils import reset_warning_once
+
+    reset_warning_once()
+
+    # Force urllib path and stub sleep
+    monkeypatch.setattr(
+        "github2gerrit.gerrit_rest._PygerritRestApi", None, raising=True
+    )
+    monkeypatch.setattr("time.sleep", lambda s: None, raising=False)
+
+    import urllib.error
+
+    def _fake_urlopen(req: Any, timeout: float | None = None) -> _DummyResp:
+        headers: Message[str, str] = Message()
+        raise urllib.error.HTTPError(
+            url="https://gerrit.example.org/changes/?q=owner:self",
+            code=403,
+            msg="Forbidden",
+            hdrs=headers,
+            fp=io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "github2gerrit.gerrit_rest.urllib.request.urlopen",
+        _fake_urlopen,
+        raising=True,
+    )
+
+    client = GerritRestClient(
+        base_url="https://gerrit.example.org/",
+        timeout=0.1,
+        max_attempts=3,
+    )
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(GerritRestError) as ei,
+    ):
+        client.get("/changes/?q=owner:self&n=1")
+
+    assert ei.value.status == 403
+    assert ei.value.is_auth_error is True
+
+    auth_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+        and "authentication failed" in rec.getMessage().lower()
+    ]
+    assert len(auth_warnings) == 1
+
+
+def test_gerrit_rest_403_warning_is_deduplicated(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeated 403s within a run must warn at most once."""
+    from github2gerrit.utils import reset_warning_once
+
+    reset_warning_once()
+
+    monkeypatch.setattr(
+        "github2gerrit.gerrit_rest._PygerritRestApi", None, raising=True
+    )
+    monkeypatch.setattr("time.sleep", lambda s: None, raising=False)
+
+    import urllib.error
+
+    def _fake_urlopen(req: Any, timeout: float | None = None) -> _DummyResp:
+        headers: Message[str, str] = Message()
+        raise urllib.error.HTTPError(
+            url="https://gerrit.example.org/changes/?q=owner:self",
+            code=403,
+            msg="Forbidden",
+            hdrs=headers,
+            fp=io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "github2gerrit.gerrit_rest.urllib.request.urlopen",
+        _fake_urlopen,
+        raising=True,
+    )
+
+    client = GerritRestClient(
+        base_url="https://gerrit.example.org/",
+        timeout=0.1,
+        max_attempts=1,
+    )
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            with pytest.raises(GerritRestError):
+                client.get("/changes/?q=owner:self&n=1")
+
+    auth_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+        and "authentication failed" in rec.getMessage().lower()
+    ]
+    assert len(auth_warnings) == 1
+
+
+def test_warn_gerrit_credentials_unavailable_warns_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared credentials-unavailable helper must warn once per run."""
+    from github2gerrit.gerrit_rest import warn_gerrit_credentials_unavailable
+    from github2gerrit.utils import reset_warning_once
+
+    reset_warning_once()
+
+    with caplog.at_level(logging.WARNING):
+        warn_gerrit_credentials_unavailable()
+        warn_gerrit_credentials_unavailable()
+        warn_gerrit_credentials_unavailable()
+
+    creds_warnings = [
+        rec
+        for rec in caplog.records
+        if "credentials are not available" in rec.getMessage().lower()
+    ]
+    assert len(creds_warnings) == 1

--- a/tests/test_orphan_rest_side_effects.py
+++ b/tests/test_orphan_rest_side_effects.py
@@ -21,6 +21,9 @@ class MockGerritRestClient:
     def __init__(self):
         self.post_calls = []
         self.should_fail = {}
+        # Mirror the real GerritRestClient interface: these tests simulate
+        # an authenticated client that can perform mutating REST calls.
+        self.is_authenticated = True
 
     def post(self, path: str, data: dict | None = None):
         """Record POST calls and optionally simulate failures."""

--- a/tests/test_reconciliation_plan_and_orphans.py
+++ b/tests/test_reconciliation_plan_and_orphans.py
@@ -157,6 +157,8 @@ def test_topic_reuse_and_orphan_policy_comment(
 
     # Mock Gerrit REST client for comment operations
     class MockRestClient:
+        is_authenticated = True
+
         def post(self, path, data=None):
             # Simulate successful REST operation
             return {"message": "comment added"}
@@ -230,6 +232,8 @@ def test_orphan_policy_variants(policy, expected_field, caplog, monkeypatch):
 
     # Mock Gerrit REST client for all policies (abandon/comment operations)
     class MockRestClient:
+        is_authenticated = True
+
         def post(self, path, data=None):
             # Simulate successful REST operation
             return {"message": "operation completed"}
@@ -280,6 +284,8 @@ def test_comment_based_reuse_extension_digest(caplog, monkeypatch):
     # Mock Gerrit REST client (no orphan actions expected, but needed for
     # consistency)
     class MockRestClient:
+        is_authenticated = True
+
         def post(self, path, data=None):
             return {"message": "operation completed"}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import tempfile
+import threading
 
 from _pytest.logging import LogCaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
@@ -15,7 +16,9 @@ from github2gerrit.utils import env_bool
 from github2gerrit.utils import env_str
 from github2gerrit.utils import is_verbose_mode
 from github2gerrit.utils import log_exception_conditionally
+from github2gerrit.utils import log_warning_once
 from github2gerrit.utils import parse_bool_env
+from github2gerrit.utils import reset_warning_once
 
 
 class TestEnvBool:
@@ -331,6 +334,84 @@ class TestLogExceptionConditionally:
         assert "Test message: arg1" in caplog.text
         # In non-verbose mode, the full traceback should not be present
         assert caplog.records[0].levelname == "ERROR"
+
+
+class TestLogWarningOnce:
+    """Test the log_warning_once warn-once helper."""
+
+    def test_warns_once_for_same_key(self, caplog: LogCaptureFixture) -> None:
+        """Repeated calls with the same key emit a single warning."""
+        reset_warning_once()
+        logger = logging.getLogger("test.warn_once")
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                log_warning_once(logger, "dup_key", "degraded: %s", "reason")
+
+        matching = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+            and "degraded: reason" in rec.getMessage()
+        ]
+        assert len(matching) == 1
+
+    def test_distinct_keys_each_warn(self, caplog: LogCaptureFixture) -> None:
+        """Different keys are tracked independently."""
+        reset_warning_once()
+        logger = logging.getLogger("test.warn_once")
+
+        with caplog.at_level(logging.WARNING):
+            log_warning_once(logger, "key_a", "first")
+            log_warning_once(logger, "key_b", "second")
+
+        messages = [rec.getMessage() for rec in caplog.records]
+        assert "first" in messages
+        assert "second" in messages
+
+    def test_thread_safe_warns_once_under_concurrency(
+        self, caplog: LogCaptureFixture
+    ) -> None:
+        """Concurrent callers must still produce exactly one warning.
+
+        PRs are processed in parallel via a ThreadPoolExecutor, so the
+        check-and-record step must be atomic. Many threads racing on the
+        same key must not bypass the warn-once guarantee.
+        """
+        reset_warning_once()
+        logger = logging.getLogger("test.warn_once")
+
+        num_threads = 50
+        start = threading.Barrier(num_threads)
+        errors: list[Exception] = []
+
+        def _worker() -> None:
+            try:
+                # Bounded wait so a stalled worker fails fast (raising
+                # BrokenBarrierError) instead of deadlocking the test run.
+                start.wait(timeout=10)
+                log_warning_once(logger, "race_key", "raced warning")
+            except Exception as exc:
+                errors.append(exc)
+
+        with caplog.at_level(logging.WARNING):
+            threads = [
+                threading.Thread(target=_worker) for _ in range(num_threads)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=15)
+
+        # No worker should have stalled at the barrier or otherwise raised.
+        assert not errors
+        # Every thread must have terminated (no leaked/blocked threads).
+        assert all(not thread.is_alive() for thread in threads)
+
+        matching = [
+            rec for rec in caplog.records if "raced warning" in rec.getMessage()
+        ]
+        assert len(matching) == 1
 
 
 class TestAppendGithubOutput:


### PR DESCRIPTION
## Problem

The dependency supersession sweep issues a Gerrit REST query containing
`owner:self`, which requires an authenticated Gerrit session. In the common
SSH-only deployment (e.g. the LF dependabot → Gerrit flow) no HTTP credentials
are present, so the request is **guaranteed** to fail with `HTTP 403`.

The failure was handled functionally (the caller swallowed it and returned no
candidates), but it was:

- **Noisy** under verbose mode — two `ERROR` lines plus full tracebacks from
  the REST and retry layers for an entirely expected condition; and
- **Invisible** at the default log level — operators had no signal that a
  feature had silently degraded due to missing credentials.

A holistic review showed the `owner:self` chokepoint was the only authenticated
call site missing the `is_authenticated` guard that siblings such as
`_update_gerrit_change_metadata` and `_verify_gerrit_rest` already use, and that
even the existing guard logged at `debug` (silent).

## Changes

Handle authentication-gated Gerrit operations consistently:

- **Skip before failing.** `query_open_changes_by_project` (the only
  `owner:self` query) and the reconciliation orphan abandon/comment write paths
  now check `client.is_authenticated` and skip when unauthenticated, instead of
  issuing a request that cannot succeed.
- **Make degradation visible.** Skips surface a single, default-visible
  `WARNING` (not a silent `debug` line and not an error traceback). The
  `_update_gerrit_change_metadata` no-credentials branch was promoted from
  `debug` to this warning.
- **Classify auth failures.** `GerritRestError` now carries `.status` and an
  `.is_auth_error` flag. `HTTP 401/403` are logged once as a concise warning,
  and the `external_api` retry decorator no longer emits a duplicate error for
  them.
- **Warn once per run.** A shared `log_warning_once()` helper (with
  `reset_warning_once()` for tests) ensures the "no Gerrit REST credentials"
  situation is reported at most once per run regardless of how many operations
  are affected.

No behavior change for the authenticated case, and no behavior change to the
functional outcome of the unauthenticated case (still returns no candidates) —
only the logging/visibility and the avoidance of a guaranteed-403 request.

## Tests

- New: unauthenticated `owner:self` short-circuits without sending a request;
  403 sets `.status`/`.is_auth_error` and warns once; repeated 403s deduplicate
  to a single warning; `warn_gerrit_credentials_unavailable()` warns once.
- Updated mock REST clients in `test_orphan_rest_side_effects.py` and
  `test_reconciliation_plan_and_orphans.py` to expose `is_authenticated`,
  matching the real `GerritRestClient` interface.

## Validation

`ruff` and `mypy` clean on all touched files; full pytest suite passes (the
pre-existing environmental `test_ssh_agent_real_workflow`, which spawns a real
`ssh-agent`, is unrelated to this change).
