### PR TITLE
Feat: anonymous fallback for supersession sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,29 @@ variable.
 **Note**: Unknown configuration keys will generate warnings to help catch typos
 and missing functionality.
 
+### Supersession Sweep Without REST Credentials
+
+The dependency **supersession sweep** (which reuses or abandons older open
+Gerrit changes when GitHub2Gerrit pushes a newer update for the same
+dependency) needs to list GitHub2Gerrit's own open changes. With Gerrit REST
+credentials it does this precisely via the `owner:self` query operator.
+
+`owner:self` requires an authenticated session, so without Gerrit REST
+credentials the tool falls back to an **anonymous** query: it lists the
+project/branch's open GitHub2Gerrit changes (narrowed server-side via the
+`GitHub-PR` trailer, a public read-only operation) and then keeps only those
+whose trailer points at the current repository. This scopes the sweep to
+GitHub2Gerrit changes for this repository without needing a Gerrit HTTP
+password.
+
+- Use `G2G_ANON_SUPERSEDE_FALLBACK` (default `true`) to control the fallback.
+- Set it to `false` to disable the fallback; without credentials the tool then
+  skips the sweep and logs a warning, as before.
+- The fallback depends on the Gerrit server allowing anonymous change queries.
+  If the server rejects that query, the tool skips the sweep gracefully.
+- On large projects the query has a result cap; if it reaches that cap the
+  tool warns that the sweep may be incomplete.
+
 ### Credential Derivation
 
 When `GERRIT_SSH_USER_G2G` and `GERRIT_SSH_USER_G2G_EMAIL` are not explicitly provided,

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -969,6 +969,7 @@ class Orchestrator:
                     gerrit.project,
                     branch=gh.base_ref,
                     max_results=200,
+                    github_repository=gh.repository,
                 )
 
                 # Collect all matching changes, then select the
@@ -2178,6 +2179,7 @@ class Orchestrator:
                         exclude_change_ids=prep.change_ids,
                         dry_run=False,
                         target_branch=self._resolve_target_branch(),
+                        github_repository=gh.repository,
                     )
             except Exception as exc:
                 log.debug("Post-push supersession sweep skipped: %s", exc)

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -1780,6 +1780,7 @@ def abandon_superseded_dependency_changes(
     *,
     dry_run: bool = False,
     target_branch: str | None = None,
+    github_repository: str | None = None,
 ) -> list[str]:
     """Abandon open Gerrit changes superseded by a newer dependency update.
 
@@ -1801,6 +1802,10 @@ def abandon_superseded_dependency_changes(
         dry_run: If True, log but do not actually abandon.
         target_branch: Optional Gerrit branch name.  When provided,
             only changes targeting this branch are considered.
+        github_repository: Current GitHub repository in ``owner/repo``
+            form. Enables the anonymous supersession fallback when no
+            Gerrit REST credentials are available (the discovery query is
+            then scoped to this repository via the ``GitHub-PR`` trailer).
 
     Returns:
         List of Gerrit change numbers that were abandoned
@@ -1830,7 +1835,11 @@ def abandon_superseded_dependency_changes(
     try:
         client = build_client_for_host(gerrit_server)
         open_changes = query_open_changes_by_project(
-            client, gerrit_project, branch=target_branch, max_results=200
+            client,
+            gerrit_project,
+            branch=target_branch,
+            max_results=200,
+            github_repository=github_repository,
         )
 
         url_builder = create_gerrit_url_builder(gerrit_server)

--- a/src/github2gerrit/gerrit_query.py
+++ b/src/github2gerrit/gerrit_query.py
@@ -11,9 +11,14 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
+from urllib.parse import urlparse
 
 from .gerrit_rest import GerritRestClient
 from .gerrit_rest import warn_gerrit_credentials_unavailable
+from .trailers import GITHUB_PR_TRAILER
+from .trailers import parse_trailers
+from .utils import env_bool
+from .utils import log_warning_once
 
 
 log = logging.getLogger(__name__)
@@ -121,19 +126,71 @@ def query_changes_by_topic(
         return changes
 
 
+def _change_belongs_to_repository(
+    change: GerritChange, github_repository: str
+) -> bool:
+    """Return True if a change's GitHub-PR trailer targets the given repo.
+
+    The ``GitHub-PR`` trailer is a pull request URL of the form
+    ``https://github.com/{owner}/{repo}/pull/{n}``. Matching on it scopes
+    anonymous supersession queries to changes created by GitHub2Gerrit for
+    the current repository -- a precise replacement for ``owner:self`` that
+    does not require an authenticated session.
+
+    The trailer is parsed as a URL and matched on its **path** prefix
+    (``/{owner}/{repo}/pull/``) rather than a bare substring. The value must
+    be an absolute ``http(s)`` URL (scheme + host), so malformed or
+    relative values (e.g. ``/org/repo/pull/1``) and unrelated text that
+    merely contains the substring (for example inside a query string) do
+    not produce false positives. The host itself is not compared, so
+    GitHub Enterprise URLs still match.
+    """
+    target = github_repository.strip().strip("/").lower()
+    if not target:
+        return False
+    prefix = f"/{target}/pull/"
+    trailers = parse_trailers(change.commit_message or "")
+    for value in trailers.get(GITHUB_PR_TRAILER, []):
+        if not value:
+            continue
+        try:
+            parsed = urlparse(value.strip())
+        except ValueError:
+            continue
+        # Require an absolute http(s) URL; reject relative/malformed values.
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            continue
+        if parsed.path.lower().startswith(prefix):
+            return True
+    return False
+
+
 def query_open_changes_by_project(
     client: GerritRestClient,
     project: str,
     *,
     branch: str | None = None,
     max_results: int = 100,
+    github_repository: str | None = None,
 ) -> list[GerritChange]:
-    """Query open changes owned by the current user in a Gerrit project.
+    """Query open GitHub2Gerrit changes in a Gerrit project.
 
-    Used by the supersession sweep to discover open changes that
-    may be superseded by a newer dependency update.  Only returns
-    changes owned by the authenticated user (``owner:self``) to
-    avoid acting on unrelated human-authored changes.
+    Used by the supersession sweep to discover open changes that may be
+    superseded by a newer dependency update.
+
+    When the REST client is authenticated, the query is restricted to
+    changes owned by the authenticated user via the ``owner:self``
+    predicate (the original, most precise behaviour).
+
+    When the client is unauthenticated, ``owner:self`` cannot be used (the
+    server rejects it with HTTP 403). If the anonymous fallback is enabled
+    (``G2G_ANON_SUPERSEDE_FALLBACK``, default on) and ``github_repository``
+    is provided, the query instead lists all open changes in the
+    project/branch and keeps only those whose ``GitHub-PR`` trailer targets
+    ``github_repository``. This scopes results to GitHub2Gerrit changes for
+    the current repository without requiring credentials. If the fallback
+    is disabled or no repository is available, the sweep is skipped (with a
+    warning) as before.
 
     Args:
         client: Gerrit REST client.
@@ -142,37 +199,61 @@ def query_open_changes_by_project(
             When provided, only changes targeting this branch are
             returned.
         max_results: Maximum number of results to return.
+        github_repository: Current GitHub repository in ``owner/repo``
+            form. Required to enable the anonymous fallback.
 
     Returns:
         List of open ``GerritChange`` objects.
     """
-    query = f'project:"{_gerrit_quote(project)}" status:open owner:self'
+    base_query = f'project:"{_gerrit_quote(project)}" status:open'
     if branch:
-        query += f' branch:"{_gerrit_quote(branch)}"'
+        base_query += f' branch:"{_gerrit_quote(branch)}"'
 
-    # The ``owner:self`` predicate requires an authenticated Gerrit
-    # session; an anonymous request is rejected with HTTP 403. Skip the
-    # query (warning once per run) instead of issuing a request that is
-    # guaranteed to fail and would otherwise emit error-level noise.
-    if not client.is_authenticated:
+    repo_filter: str | None = None
+    if client.is_authenticated:
+        query = f"{base_query} owner:self"
+    else:
+        # owner:self requires an authenticated session. Fall back to an
+        # anonymous project/branch query scoped to the current repository
+        # via the GitHub-PR trailer, when permitted and possible.
+        normalized_repo = (github_repository or "").strip().strip("/")
+        fallback_enabled = env_bool("G2G_ANON_SUPERSEDE_FALLBACK", True)
+        if not fallback_enabled or not normalized_repo:
+            warn_gerrit_credentials_unavailable()
+            log.debug(
+                "Skipping owner:self query for project '%s': no Gerrit "
+                "REST credentials and anonymous fallback unavailable "
+                "(enabled=%s, repository=%s)",
+                project,
+                fallback_enabled,
+                normalized_repo,
+            )
+            return []
+        # owner:self is unavailable without authentication. Narrow the
+        # anonymous query server-side to GitHub2Gerrit changes (which all
+        # carry the GitHub-PR trailer in their commit message) so the
+        # result set stays small even on busy projects; the precise
+        # repository scoping is then applied client-side below.
+        query = f'{base_query} message:"{GITHUB_PR_TRAILER}"'
+        repo_filter = normalized_repo
+        # Surface the missing-credentials condition once at default level
+        # via the shared warn-once helper (its message already notes that
+        # fallback behavior may apply); keep the per-call detail at debug,
+        # since this can run multiple times per invocation (e.g. Strategy 5
+        # and the post-push sweep).
         warn_gerrit_credentials_unavailable()
         log.debug(
-            "Skipping owner:self query for project '%s': "
-            "no Gerrit REST credentials available",
+            "No Gerrit REST credentials; using anonymous supersession "
+            "fallback for project '%s' scoped to repository '%s'",
             project,
+            normalized_repo,
         )
-        return []
 
     log.debug("Querying Gerrit for open changes: %s", query)
 
     try:
         changes = _execute_query_with_pagination(
             client, query, max_results=max_results
-        )
-        log.debug(
-            "Found %d open changes in project '%s'",
-            len(changes),
-            project,
         )
     except Exception as exc:
         log.warning(
@@ -181,8 +262,44 @@ def query_open_changes_by_project(
             exc,
         )
         return []
-    else:
-        return changes
+
+    if repo_filter is not None:
+        # The cap may simply have been met exactly, but it can also mean
+        # the result set was truncated; surface the possibility once rather
+        # than silently missing changes (which could leave a duplicate
+        # un-reused/un-abandoned).
+        if len(changes) >= max_results:
+            log_warning_once(
+                log,
+                "gerrit_anon_supersede_truncated",
+                "Anonymous supersession query for project '%s' returned the "
+                "maximum of %d result(s); results may be truncated and some "
+                "GitHub2Gerrit changes may not have been examined. Provide "
+                "Gerrit REST credentials for a precise owner-scoped query.",
+                project,
+                max_results,
+            )
+        scoped = [
+            change
+            for change in changes
+            if _change_belongs_to_repository(change, repo_filter)
+        ]
+        log.debug(
+            "Anonymous fallback: %d of %d open change(s) in project "
+            "'%s' belong to repository '%s'",
+            len(scoped),
+            len(changes),
+            project,
+            repo_filter,
+        )
+        return scoped
+
+    log.debug(
+        "Found %d open changes in project '%s'",
+        len(changes),
+        project,
+    )
+    return changes
 
 
 def _execute_query_with_pagination(

--- a/tests/test_dependency_supersession.py
+++ b/tests/test_dependency_supersession.py
@@ -22,6 +22,8 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
+
 from github2gerrit.core import Orchestrator
 from github2gerrit.gerrit_pr_closer import abandon_superseded_dependency_changes
 from github2gerrit.gerrit_query import GerritChange
@@ -61,6 +63,35 @@ def _gerrit_change(
         commit_message=commit_message,
         topic=topic,
     )
+
+
+def _raw_change(
+    number: int,
+    subject: str,
+    pr_url: str | None = None,
+) -> dict[str, Any]:
+    """Build a raw Gerrit REST change dict (as returned by /changes/).
+
+    When ``pr_url`` is provided, a ``GitHub-PR`` trailer is added to the
+    current revision's commit message so the anonymous repo-scoping filter
+    can be exercised.
+    """
+    message = subject
+    if pr_url:
+        message = f"{subject}\n\nGitHub-PR: {pr_url}\n"
+    return {
+        "change_id": f"I{number}",
+        "_number": number,
+        "subject": subject,
+        "status": "NEW",
+        "current_revision": "rev1",
+        "revisions": {
+            "rev1": {
+                "files": {},
+                "commit": {"message": message},
+            }
+        },
+    }
 
 
 # -------------------------------------------------------------------
@@ -164,11 +195,12 @@ class TestQueryOpenChangesByProject:
         assert result == []
 
     def test_skips_when_unauthenticated(self) -> None:
-        """owner:self requires auth; skip (no request) when unauthenticated.
+        """Unauthenticated with no repository: skip (no request issued).
 
         Without Gerrit REST credentials the ``owner:self`` query is
-        guaranteed to fail with HTTP 403, so the helper must short-circuit
-        and never issue the request, returning an empty list.
+        guaranteed to fail with HTTP 403. When no repository is available
+        to drive the anonymous fallback, the helper must short-circuit and
+        never issue the request, returning an empty list.
         """
         from github2gerrit.utils import reset_warning_once
 
@@ -179,6 +211,227 @@ class TestQueryOpenChangesByProject:
 
         result = query_open_changes_by_project(fake_client, "org/repo")
 
+        assert result == []
+        fake_client.get.assert_not_called()
+
+    def test_authenticated_uses_owner_self(self) -> None:
+        """Authenticated client must use the owner:self predicate."""
+        fake_client = MagicMock()
+        fake_client.is_authenticated = True
+        fake_client.get.return_value = []
+
+        query_open_changes_by_project(fake_client, "org/repo", branch="main")
+
+        path = fake_client.get.call_args[0][0]
+        # owner:self is URL-encoded as owner%3Aself in the query string
+        assert "owner%3Aself" in path
+
+    def test_anonymous_fallback_scopes_to_repository(self) -> None:
+        """Unauthenticated + repo: query anonymously, scope by trailer.
+
+        The query must NOT use owner:self, and only changes whose
+        GitHub-PR trailer targets the current repository are returned.
+        """
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        ours = _raw_change(
+            100,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "https://github.com/org/repo/pull/42",
+        )
+        other_repo = _raw_change(
+            101,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "https://github.com/other/project/pull/7",
+        )
+        human = _raw_change(102, "Fix: unrelated human change")
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = [ours, other_repo, human]
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+
+        path = fake_client.get.call_args[0][0]
+        assert "owner%3Aself" not in path
+        assert [change.number for change in result] == ["100"]
+
+    def test_anonymous_fallback_repo_match_is_case_insensitive(self) -> None:
+        """Repo trailer matching ignores case differences."""
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        ours = _raw_change(
+            200,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "https://github.com/Org/Repo/pull/9",
+        )
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = [ours]
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+        assert [change.number for change in result] == ["200"]
+
+    def test_anonymous_fallback_matches_ghes_host(self) -> None:
+        """The host is ignored, so GitHub Enterprise URLs still match."""
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        ours = _raw_change(
+            210,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "https://ghe.example.com/org/repo/pull/9",
+        )
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = [ours]
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+        assert [change.number for change in result] == ["210"]
+
+    def test_anonymous_fallback_rejects_substring_in_query(self) -> None:
+        """Non-absolute or substring-only repo references must not match.
+
+        The matcher requires an absolute http(s) URL and checks its path
+        prefix, so a different repo's URL that merely mentions the target
+        repo in its query string, a non-URL value, and a relative path
+        (e.g. ``/org/repo/pull/1``) are all correctly excluded.
+        """
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        other = _raw_change(
+            220,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "https://github.com/other/project/pull/7?ref=/org/repo/pull/1",
+        )
+        malformed = _raw_change(
+            221,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "not-a-url-/org/repo/pull/1",
+        )
+        relative = _raw_change(
+            222,
+            "chore: bump requests from 2.31.0 to 2.32.0",
+            "/org/repo/pull/1",
+        )
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = [other, malformed, relative]
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+        assert result == []
+
+    def test_anonymous_fallback_narrows_query_by_message(self) -> None:
+        """The anonymous query narrows server-side via message:GitHub-PR.
+
+        Without owner:self, the result set is reduced server-side to
+        GitHub2Gerrit changes (which carry the GitHub-PR trailer) so busy
+        projects do not truncate before the relevant changes are seen.
+        """
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = []
+
+        query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+
+        path = fake_client.get.call_args[0][0]
+        assert "owner%3Aself" not in path
+        # message:"GitHub-PR" is URL-encoded in the query string
+        assert "message%3A%22GitHub-PR%22" in path
+
+    def test_anonymous_fallback_warns_on_truncation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Hitting the result cap emits a one-time truncation warning."""
+        import logging
+
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        c1 = _raw_change(
+            300,
+            "chore: bump x from 1 to 2",
+            "https://github.com/org/repo/pull/1",
+        )
+        c2 = _raw_change(
+            301,
+            "chore: bump y from 1 to 2",
+            "https://github.com/org/repo/pull/2",
+        )
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+        fake_client.get.return_value = [c1, c2]
+
+        with caplog.at_level(logging.WARNING):
+            result = query_open_changes_by_project(
+                fake_client,
+                "org/repo",
+                github_repository="org/repo",
+                max_results=2,
+            )
+
+        assert {change.number for change in result} == {"300", "301"}
+        assert any(
+            "results may be truncated" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_anonymous_fallback_disabled_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Disabling the fallback flag skips even when repo is known."""
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+        monkeypatch.setenv("G2G_ANON_SUPERSEDE_FALLBACK", "false")
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="org/repo"
+        )
+        assert result == []
+        fake_client.get.assert_not_called()
+
+    def test_anonymous_fallback_whitespace_repo_skips(self) -> None:
+        """A blank/whitespace-only repository must not trigger a query."""
+        from github2gerrit.utils import reset_warning_once
+
+        reset_warning_once()
+
+        fake_client = MagicMock()
+        fake_client.is_authenticated = False
+
+        result = query_open_changes_by_project(
+            fake_client, "org/repo", github_repository="   "
+        )
         assert result == []
         fake_client.get.assert_not_called()
 
@@ -467,6 +720,7 @@ class TestAbandonSupersededDependencyChanges:
             current_subject="chore: bump requests from 2.31.0 to 2.32.0",
             exclude_change_ids=[],
             target_branch="main",
+            github_repository="org/repo-gh",
         )
 
         mock_query.assert_called_once_with(
@@ -474,6 +728,7 @@ class TestAbandonSupersededDependencyChanges:
             "org/repo",
             branch="main",
             max_results=200,
+            github_repository="org/repo-gh",
         )
 
 


### PR DESCRIPTION
## Summary

Makes the dependency **supersession sweep** work without Gerrit REST credentials, by routing around the `owner:self` operator with an anonymous, public-API query — the design we discussed for the `lfit` org, where Gerrit HTTP passwords are deliberately not provisioned.

## Background

The sweep (reuse the oldest open change for a dependency, or abandon superseded ones after a newer push) lists GitHub2Gerrit's own open changes via:

```
/changes/?q=project:"…" status:open owner:self branch:"…"  → 403 "Must be signed-in to use this operator"
```

`owner:self` is the **only** part that needs authentication. I verified directly against `gerrit.linuxfoundation.org`:

| Anonymous query | Result |
| --- | --- |
| `project:"releng/docs-conf" status:open` (+ `CURRENT_REVISION,CURRENT_FILES,CURRENT_COMMIT`) | **HTTP 200**, full change objects incl. commit messages/trailers |
| same query **+ `owner:self`** | **HTTP 403** "Must be signed-in to use this operator" |

## Change

`owner:self` was only ever a coarse proxy for "changes this bot created." The callers already filter results by the `GitHub-PR` trailer, and that trailer is a full PR URL — so we can bind a change to the **current GitHub repo** precisely, anonymously.

- `query_open_changes_by_project()` is now auth-aware:
  - **Authenticated** → unchanged `owner:self` query (most precise).
  - **Unauthenticated** → if the anonymous fallback is enabled and a repository is known, query `project + branch + status:open` (public, read-only) and keep only changes whose `GitHub-PR` trailer targets the current repo. Otherwise skip with the existing warn-once.
- New `_change_belongs_to_repository()` helper (case-insensitive repo match on the `GitHub-PR` trailer URL).
- `github_repository` threaded through **Strategy 5** (`_find_existing_change_for_pr`) and **`abandon_superseded_dependency_changes`**. The abandon itself still runs over **SSH**, so the whole flow needs no HTTP credentials.
- Gated by **`G2G_ANON_SUPERSEDE_FALLBACK`** (default `true`); set `false` to keep the previous skip-with-warning behaviour.
- README section documents the behaviour and the flag.

## Safety

- The repo-scoped `GitHub-PR` trailer filter is **more** precise than `owner:self` for our purpose: it restricts to GitHub2Gerrit changes for *this* repository. Combined with the existing dependency-package + branch + `exclude_change_ids` filters, the abandon path is tightly scoped. Given the 1:1 repo↔project mapping and single bot, the residual risk versus `owner:self` is effectively nil.
- Strictly additive: authenticated behaviour is unchanged; with the flag off, behaviour is identical to today.
- Server-dependent: if a Gerrit server rejects anonymous change listing, the query errors are caught and the sweep is skipped gracefully.

## Tests / validation

- New tests: authenticated uses `owner:self`; unauthenticated scopes to repo via trailer (and excludes other-repo/human changes); case-insensitive repo match; fallback-disabled and no-repository both skip without issuing a request.
- `ruff`, `mypy`, `basedpyright`, `markdownlint`, `write-good` all clean; full pytest suite passes (only the environmental `ssh_agent_real_workflow` deselected).
