### PR TITLE
Chore: clear CodeQL code-quality warnings

### DIFF
--- a/scripts/demo_trailer_functionality.py
+++ b/scripts/demo_trailer_functionality.py
@@ -347,4 +347,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -504,9 +504,12 @@ def _resolve_org(default_org: str | None) -> str:
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., object])
 
-    def typed_app_command(
-        *args: object, **kwargs: object
-    ) -> Callable[[F], F]: ...
+    # Typed stub so basedpyright treats @typed_app_command as a typed
+    # decorator. The body raises rather than using an ellipsis so static
+    # analysers do not model it as a procedure that returns None; this
+    # branch is never executed at runtime.
+    def typed_app_command(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
 else:
     typed_app_command = app.command
 
@@ -865,7 +868,7 @@ def main(
     ) -> bool:
         """Return *current* if the CLI flag was explicit, else parse env."""
         source = ctx.get_parameter_source(param_name)  # pyright: ignore[reportAttributeAccessIssue]
-        if source == click.core.ParameterSource.COMMANDLINE:  # pyright: ignore[reportAttributeAccessIssue]
+        if source == click.core.ParameterSource.COMMANDLINE:  # pyright: ignore[reportAttributeAccessIssue, reportUnnecessaryComparison]
             return current
         env_val = os.getenv(env_var)
         if env_val is not None:

--- a/src/github2gerrit/gerrit_rest.py
+++ b/src/github2gerrit/gerrit_rest.py
@@ -321,7 +321,6 @@ class GerritRestClient:
             )
 
             with urllib.request.urlopen(req, timeout=self._timeout) as resp:
-                status = getattr(resp, "status", None)
                 content = resp.read()
                 # Gerrit prepends ")]}'" in JSON responses to prevent JSON
                 # hijacking; strip if present

--- a/src/github2gerrit/ssh_config_parser.py
+++ b/src/github2gerrit/ssh_config_parser.py
@@ -272,8 +272,9 @@ class SSHConfig:
         try:
             return bool(re.match(regex_pattern, hostname))
         except re.error:
-            # If regex is invalid, fall back to exact match
-            return pattern == hostname
+            # An invalid regex cannot match. The exact-match case is
+            # already handled above, so there is nothing left to match.
+            return False
 
 
 # Global cache for SSH config instances to avoid re-parsing

--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -28,7 +28,12 @@ from github2gerrit.config import overlay_missing
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., object])
 
-    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]: ...
+    # Typed stub so basedpyright treats @parametrize as a typed decorator
+    # (reportUntypedFunctionDecorator). The body raises rather than using
+    # an ellipsis so static analysers do not model it as a procedure that
+    # returns None; this code is never executed at runtime.
+    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
 else:
     from pytest import mark
 

--- a/tests/test_core_config_and_errors.py
+++ b/tests/test_core_config_and_errors.py
@@ -287,7 +287,11 @@ def test_configure_git_raises_on_git_review_init_failure(
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., object])
 
-    def fixture(*args: object, **kwargs: object) -> Callable[[F], F]: ...
+    # Typed stub (raising body, never executed) so basedpyright treats
+    # @fixture as a typed decorator and static analysers do not model it
+    # as a procedure returning None.
+    def fixture(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
 else:
     fixture = pytest.fixture
 

--- a/tests/test_core_ssh_setup.py
+++ b/tests/test_core_ssh_setup.py
@@ -52,8 +52,14 @@ def snapshot_dir_state(directory: Path) -> dict[str, str]:
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., object])
 
-    def fixture(*args: object, **kwargs: object) -> Callable[[F], F]: ...
-    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]: ...
+    # Typed stubs (raising bodies, never executed) so basedpyright treats
+    # @fixture/@parametrize as typed decorators and static analysers do not
+    # model them as procedures returning None.
+    def fixture(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
+
+    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
 else:
     from pytest import fixture as _fixture
     from pytest import mark as _mark

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -11,7 +11,11 @@ from typing import TypeVar
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., object])
 
-    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]: ...
+    # Typed stub (raising body, never executed) so basedpyright treats
+    # @parametrize as a typed decorator and static analysers do not model
+    # it as a procedure returning None.
+    def parametrize(*args: object, **kwargs: object) -> Callable[[F], F]:
+        raise NotImplementedError
 else:
     from pytest import mark
 


### PR DESCRIPTION
## Summary

Clears the **warnings** flagged by the GitHub **Code Quality (CodeQL, preview)** service for this project.

> **Stacked on #285** (anonymous supersession fallback). This branch was created from #285's head per request; the two changesets touch disjoint files. Until #285 merges, this PR's diff will include #285's commit — merge #285 first, then this rebases cleanly to just the code-quality commit.

## Warnings addressed

**Use of the return value of a procedure (6)** — `cli.py:551`, `tests/test_config_helpers.py` (×2), `tests/test_core_config_and_errors.py`, `tests/test_core_ssh_setup.py`, `tests/test_url_parser.py`.
These are `TYPE_CHECKING`-only decorator stubs (`typed_app_command`, `fixture`, `parametrize`) used to give the decorators a precise type for basedpyright (`reportUntypedFunctionDecorator`). Their `...` body made CodeQL model them as procedures that return `None`, so the `@decorator(...)` usage looked like "using a None result". Changed the body to `raise NotImplementedError` — the typed signature (and runtime behaviour, which never executes these branches) is unchanged, but they're no longer modelled as None-returning.

**Variable defined multiple times (1)** — `gerrit_rest.py:324`. Removed the dead `status = getattr(resp, "status", None)` in the success path (it was redefined in the error paths and never read on success).

**Redundant comparison (1)** — `ssh_config_parser.py:276`. The regex-error fallback re-tested `pattern == hostname`, which is already handled by the exact-match check earlier in the function, so it was always `False`. Now returns `False` directly with a clarifying comment.

**Use of exit() (1)** — `scripts/demo_trailer_functionality.py:350`. Uses `sys.exit()` instead of the `site`-provided `exit()`.

## Pre-existing issue also fixed

Touching `cli.py` brings it into the `src`-only basedpyright pre-commit hook's scope, which surfaced a pre-existing `reportUnnecessaryComparison` false positive on the `click.core.ParameterSource.COMMANDLINE` comparison (click's incomplete typing — same root cause as the adjacent `reportAttributeAccessIssue` suppression). Extended the existing `# pyright: ignore` to cover it.

## Scope note (deliberately not changed)

While verifying, force-running basedpyright on a test file surfaced `reportMissingParameterType` on `@patch`-injected mock params. These are **not** part of any quality gate — `[tool.pyright] include = ["src"]` and the basedpyright pre-commit hook is `files: ^src/.+\.py$`, so the project intentionally does not strict-type tests. Annotating them would be inconsistent with that choice and unbounded, so they're left as-is.

## Validation

`ruff`, `mypy`, `basedpyright` (src, 0 errors), `markdownlint`, `write-good` clean; full pytest suite passes (only the environmental `ssh_agent_real_workflow` deselected). Final CodeQL clearance confirms on the next scan.
