### PR TITLE
Chore: clear CodeQL code quality warnings

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -57,6 +57,8 @@ def _dbg(msg: str) -> None:
         try:
             print(f"[sitecustomize] {msg}", file=sys.stderr)
         except Exception:
+            # Debug logging must never disrupt interpreter startup; if
+            # writing to stderr fails, silently drop the message.
             pass
 
 
@@ -125,6 +127,8 @@ def _collect_base_dirs(repo_root: Path) -> set[Path]:
     try:
         bases.add(Path.cwd())
     except Exception:
+        # CWD may be unavailable (e.g. deleted); skip it and continue
+        # collecting the remaining base directories.
         pass
     # Repository root (directory containing this file)
     bases.add(repo_root)
@@ -134,6 +138,8 @@ def _collect_base_dirs(repo_root: Path) -> set[Path]:
         try:
             bases.add(Path(gw))
         except Exception:
+            # A malformed GITHUB_WORKSPACE value should not abort cleanup;
+            # skip it and continue with the other base directories.
             pass
     return bases
 

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -385,12 +385,15 @@ else:
 
 
 class _FormatterProto(Protocol):
-    def write_usage(self, prog: str, args: str, prefix: str = ...) -> None: ...
+    def write_usage(self, prog: str, args: str, prefix: str = ...) -> None:
+        """Write the program usage line."""
 
 
 class _ContextProto(Protocol):
     @property
-    def command_path(self) -> str: ...
+    def command_path(self) -> str:
+        """Return the full command path."""
+        raise NotImplementedError
 
 
 class _SingleUsageGroup(BaseGroup):

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -471,13 +471,22 @@ def _resolve_issue_id_from_json(json_str: str, github_actor: str) -> str:
     return ""
 
 
-# Show version information when --help is used or in GitHub Actions mode
-if "--help" in sys.argv or _is_github_actions_context():
+def _print_version_banner() -> None:
+    """Print the resolved package version, or a fallback notice.
+
+    Defined as a function so the ``print`` calls do not execute at module
+    scope during import; the banner is only emitted when explicitly invoked.
+    """
     try:
         app_version = get_version("github2gerrit")
         print(f"🏷️  github2gerrit version {app_version}")
     except Exception:
         print("⚠️  github2gerrit version information not available")
+
+
+# Show version information when --help is used or in GitHub Actions mode
+if "--help" in sys.argv or _is_github_actions_context():
+    _print_version_banner()
 
 app: typer.Typer = typer.Typer(
     add_completion=False,

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -80,19 +80,10 @@ from .utils import is_verbose_mode
 
 
 try:
-    from pygerrit2 import GerritRestAPI
-    from pygerrit2 import HTTPBasicAuth
-except ImportError:
-    GerritRestAPI = None
-    HTTPBasicAuth = None
-
-try:
-    from .ssh_discovery import SSHDiscoveryError
     from .ssh_discovery import auto_discover_gerrit_host_keys
 except ImportError:
     # Fallback if ssh_discovery module is not available
     auto_discover_gerrit_host_keys = None  # type: ignore[assignment]
-    SSHDiscoveryError = Exception  # type: ignore[misc,assignment]
 
 try:
     from .ssh_agent_setup import SSHAgentManager
@@ -113,7 +104,6 @@ log = logging.getLogger("github2gerrit.core")
 
 
 # Error message constants to comply with TRY003
-_MSG_ISSUE_ID_MULTILINE = "Issue ID must be single line"
 _MSG_MISSING_PR_CONTEXT = "missing PR context"
 _MSG_BAD_REPOSITORY_CONTEXT = "bad repository context"
 _MSG_MISSING_GERRIT_SERVER = (
@@ -121,10 +111,6 @@ _MSG_MISSING_GERRIT_SERVER = (
     "input/environment variable, .gitreview file, or action configuration."
 )
 _MSG_MISSING_GERRIT_PROJECT = "missing GERRIT_PROJECT"
-_MSG_PYGERRIT2_REQUIRED_REST = "pygerrit2 is required to query Gerrit REST API"
-_MSG_PYGERRIT2_REQUIRED_AUTH = "pygerrit2 is required for HTTP authentication"
-_MSG_PYGERRIT2_MISSING = "pygerrit2 missing"
-_MSG_PYGERRIT2_AUTH_MISSING = "pygerrit2 auth missing"
 _MSG_DNS_RESOLUTION_FAILED = "DNS resolution failed for '%s'"
 
 
@@ -4429,7 +4415,6 @@ class Orchestrator:
             List of email addresses that were not found in Gerrit
         """
         combined_output = f"{exc.stdout}\n{exc.stderr}"
-        import re
 
         # Pattern to match: Account 'email@domain.com' not found
         pattern = r"Account\s+'([^']+)'\s+not\s+found"
@@ -4903,7 +4888,6 @@ class Orchestrator:
             # Extract specific rejection reason from output
             # Handle multiline rejection messages by looking in normalized
             # output
-            import re
 
             # Look for the rejection pattern in the normalized output
             rejection_match = re.search(
@@ -5299,7 +5283,6 @@ class Orchestrator:
         self, workspace: Path, gh: GitHubContext, inputs: Inputs
     ) -> None:
         """Fallback to GitHub API archive download (ported from CLI)."""
-        import json
         import zipfile
 
         repo_full = gh.repository.strip() if gh.repository else ""

--- a/src/github2gerrit/duplicate_detection.py
+++ b/src/github2gerrit/duplicate_detection.py
@@ -32,15 +32,6 @@ from .rich_display import safe_console_print
 from .trailers import extract_github_metadata
 
 
-# Optional Gerrit REST API support
-try:
-    from pygerrit2 import GerritRestAPI
-    from pygerrit2 import HTTPBasicAuth
-except ImportError:
-    GerritRestAPI = None
-    HTTPBasicAuth = None
-
-
 log = logging.getLogger(__name__)
 
 __all__ = [

--- a/src/github2gerrit/external_api.py
+++ b/src/github2gerrit/external_api.py
@@ -327,7 +327,7 @@ def external_api_call(
                 policy=policy,
             )
 
-            last_exc: BaseException | None = None
+            last_exc: Exception | None = None
 
             for attempt in range(1, policy.max_attempts + 1):
                 context.attempt = attempt
@@ -347,7 +347,7 @@ def external_api_call(
 
                     # Call the actual function
                     result = func(*args, **kwargs)
-                except BaseException as exc:
+                except Exception as exc:
                     last_exc = exc
                     duration = time.time() - context.start_time
 

--- a/src/github2gerrit/gerrit_rest.py
+++ b/src/github2gerrit/gerrit_rest.py
@@ -68,19 +68,6 @@ _MSG_PYGERRIT2_REQUIRED_AUTH: Final[str] = (
     "pygerrit2 is required for HTTP authentication"
 )
 
-_TRANSIENT_ERR_SUBSTRINGS: Final[tuple[str, ...]] = (
-    "timed out",
-    "temporarily unavailable",
-    "temporary failure",
-    "connection reset",
-    "connection aborted",
-    "broken pipe",
-    "connection refused",
-    "bad gateway",
-    "service unavailable",
-    "gateway timeout",
-)
-
 # HTTP status codes that indicate an authentication/authorization problem
 # rather than a transient fault or a bug. These are expected when no
 # Gerrit REST credentials are available (or they are insufficient for the

--- a/src/github2gerrit/github_api.py
+++ b/src/github2gerrit/github_api.py
@@ -23,7 +23,6 @@ from collections.abc import Iterable
 from importlib import import_module
 from typing import Any
 from typing import Protocol
-from typing import TypeVar
 from typing import cast
 
 from .error_codes import ExitCode
@@ -35,8 +34,6 @@ from .external_api import external_api_call
 
 # Error message constants to comply with TRY003
 _MSG_PYGITHUB_REQUIRED = "PyGithub required"
-_MSG_MISSING_GITHUB_TOKEN = "missing GITHUB_TOKEN"  # noqa: S105
-_MSG_BAD_GITHUB_REPOSITORY = "bad GITHUB_REPOSITORY"
 
 
 class GithubExceptionType(Exception):
@@ -82,8 +79,12 @@ class GhIssueComment(Protocol):
 
 
 class GhIssue(Protocol):
-    def get_comments(self) -> Iterable[GhIssueComment]: ...
-    def create_comment(self, body: str) -> None: ...
+    def get_comments(self) -> Iterable[GhIssueComment]:
+        """Return the comments on the issue."""
+        raise NotImplementedError
+
+    def create_comment(self, body: str) -> None:
+        """Create a new comment on the issue."""
 
 
 class GhPullRequest(Protocol):
@@ -91,17 +92,28 @@ class GhPullRequest(Protocol):
     title: str | None
     body: str | None
 
-    def as_issue(self) -> GhIssue: ...
-    def edit(self, *, state: str) -> None: ...
+    def as_issue(self) -> GhIssue:
+        """Return the issue view of this pull request."""
+        raise NotImplementedError
+
+    def edit(self, *, state: str) -> None:
+        """Edit the pull request state."""
 
 
 class GhRepository(Protocol):
-    def get_pull(self, number: int) -> GhPullRequest: ...
-    def get_pulls(self, state: str) -> Iterable[GhPullRequest]: ...
+    def get_pull(self, number: int) -> GhPullRequest:
+        """Return the pull request with the given number."""
+        raise NotImplementedError
+
+    def get_pulls(self, state: str) -> Iterable[GhPullRequest]:
+        """Return the pull requests with the given state."""
+        raise NotImplementedError
 
 
 class GhClient(Protocol):
-    def get_repo(self, full: str) -> GhRepository: ...
+    def get_repo(self, full: str) -> GhRepository:
+        """Return the repository for the given full name."""
+        raise NotImplementedError
 
 
 __all__ = [
@@ -119,8 +131,6 @@ __all__ = [
 ]
 
 log = logging.getLogger("github2gerrit.github_api")
-
-_T = TypeVar("_T")
 
 
 def _getenv_str(name: str) -> str:

--- a/src/github2gerrit/gitreview.py
+++ b/src/github2gerrit/gitreview.py
@@ -151,11 +151,6 @@ def derive_base_path(host: str) -> str | None:
     return _KNOWN_BASE_PATHS.get(host.lower().strip())
 
 
-# Keep a private alias so internal callers don't break if they were
-# referencing the underscore-prefixed name during development.
-_derive_base_path = derive_base_path
-
-
 # ───────────────────────────────────────────────────────────────────────
 # Pure parser
 # ───────────────────────────────────────────────────────────────────────

--- a/src/github2gerrit/gitutils.py
+++ b/src/github2gerrit/gitutils.py
@@ -555,6 +555,8 @@ def git_commit_amend(
                 if committer_email and _has_committer_signoff(body):
                     effective_signoff = False
             except GitError:
+                # Unable to read the current commit body (e.g. no HEAD yet);
+                # fall back to honoring the requested signoff setting.
                 pass
     except Exception:
         # Best effort only; default to requested signoff

--- a/src/github2gerrit/gitutils.py
+++ b/src/github2gerrit/gitutils.py
@@ -615,7 +615,6 @@ def git_commit_new(
             _tf.flush()
             tmp_path = Path(_tf.name)
         message_file = tmp_path
-        message = None
 
     # Determine whether to add -s; only suppress if message already has a
     # sign-off for current committer

--- a/src/github2gerrit/ssh_discovery.py
+++ b/src/github2gerrit/ssh_discovery.py
@@ -379,7 +379,6 @@ def save_host_keys_to_config(
             new_lines.append(f"[{organization}]")
             escaped_keys = host_keys.replace("\n", "\\n")
             new_lines.append(f'GERRIT_KNOWN_HOSTS = "{escaped_keys}"')
-            gerrit_known_hosts_updated = True
 
         # If section existed but didn't have GERRIT_KNOWN_HOSTS, add it
         elif not gerrit_known_hosts_updated:

--- a/tests/test_external_api_framework.py
+++ b/tests/test_external_api_framework.py
@@ -280,8 +280,6 @@ def test_log_api_metrics_summary(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test API metrics summary logging."""
-    import logging
-
     # Set up some metrics
     reset_api_metrics()
 

--- a/tests/test_external_api_framework.py
+++ b/tests/test_external_api_framework.py
@@ -222,6 +222,8 @@ def test_curl_download_success(
                     output_path = Path(cmd[o_index + 1])
                     output_path.write_text("downloaded content")
             except (ValueError, IndexError):
+                # No "-o" flag (or no value after it) in the mocked curl
+                # command; nothing to write, so behave like a no-op download.
                 pass
         return MockCompletedProcess()
 

--- a/tests/test_gitutils_helpers.py
+++ b/tests/test_gitutils_helpers.py
@@ -222,7 +222,7 @@ def test_git_last_commit_trailers_parsing_edge_cases(
 ) -> None:
     # Patch git_show to return a crafted commit message body with various
     # trailer forms.
-    import github2gerrit.gitutils as gitutils
+    from github2gerrit.gitutils import git_last_commit_trailers
 
     body = (
         "Subject line\n\n"
@@ -235,10 +235,12 @@ def test_git_last_commit_trailers_parsing_edge_cases(
         "Change-Id: Iabc123abc123abc123abc123abc123abc123ab\n"
     )
 
-    monkeypatch.setattr(gitutils, "git_show", lambda rev, **kw: body)
+    monkeypatch.setattr(
+        "github2gerrit.gitutils.git_show", lambda rev, **kw: body
+    )
 
     # Without filter: expect only proper footer trailers collected.
-    trailers_all = gitutils.git_last_commit_trailers()
+    trailers_all = git_last_commit_trailers()
     # Body "Key:" lines should not be extracted as trailers
     assert "Key" not in trailers_all
     # 'Empty' should be ignored due to empty value
@@ -254,7 +256,7 @@ def test_git_last_commit_trailers_parsing_edge_cases(
     ]
 
     # With filter keys: only Change-Id should be returned.
-    trailers_change = gitutils.git_last_commit_trailers(keys=["Change-Id"])
+    trailers_change = git_last_commit_trailers(keys=["Change-Id"])
     assert list(trailers_change.keys()) == ["Change-Id"]
     assert trailers_change["Change-Id"] == [
         "Ideadbeefdeadbeefdeadbeefdeadbeefdeadbeef",


### PR DESCRIPTION
## Summary

Clears the **Reliability** and **Maintainability** Code Quality
findings reported by the GitHub Code Quality (CodeQL) preview on `main`.
No runtime behaviour changes are intended (the only behavioural nuance
is that interrupts now propagate from the external API retry wrapper —
see below).

The work is split into two atomic commits.

### `Chore: clear CodeQL reliability warnings`

- **Empty except (5):** documented the intent of empty `except … : pass`
  blocks in `sitecustomize.py`, `gitutils.py` and
  `test_external_api_framework.py` so each silent `pass` states why the
  error is safely ignored.
- **Print statement at module level (2):** moved the version-banner
  `print` calls in `cli.py` into a dedicated `_print_version_banner`
  function so they no longer execute at module scope during import.
- **Except handles BaseException (1):** narrowed the retry wrapper in
  `external_api.py` to catch `Exception` instead of `BaseException`,
  allowing `KeyboardInterrupt`/`SystemExit` to propagate rather than
  being retried or recorded as API failures.

### `Chore: clear CodeQL maintainability warnings`

- **Unused global variables / type aliases:** removed defined-but-unused
  message constants and the `_T` TypeVar in `core.py`, `github_api.py`
  and `gerrit_rest.py` (plus the orphaned `TypeVar` import), and the
  unused `_derive_base_path` alias in `gitreview.py`.
- **Unused imports:** dropped the dead `pygerrit2`
  `GerritRestAPI`/`HTTPBasicAuth` optional-import fallbacks in `core.py`
  and `duplicate_detection.py`, and the unused `SSHDiscoveryError`
  import in `core.py`.
- **Module imported more than once:** removed redundant function-local
  `re`/`json` re-imports in `core.py` and a redundant `logging`
  re-import in a test.
- **Statement has no effect:** replaced ellipsis bodies on `Protocol`
  method stubs in `cli.py` and `github_api.py` with docstrings, adding
  `raise NotImplementedError` where a value-returning signature requires
  a return path under strict typing.
- **Unused local variables:** removed dead-store assignments in
  `gitutils.py` (`create_commit`) and `ssh_discovery.py`.
- **import / import-from mix:** `test_gitutils_helpers.py` now uses a
  single import style consistent with the rest of the file.

## Validation

- `ruff check` / `ruff format`: clean
- `mypy` + `basedpyright` (via pre-commit): pass
- Full test suite: **1342 passed**
- Project diagnostics: clean

Co-authored-by: Claude <claude@anthropic.com>