### PR TITLE
Test: Address AI code-quality test findings

### DIFF
--- a/tests/test_dependency_supersession.py
+++ b/tests/test_dependency_supersession.py
@@ -17,6 +17,7 @@ Covers two mechanisms:
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
@@ -31,11 +32,52 @@ from github2gerrit.gerrit_query import query_open_changes_by_project
 from github2gerrit.gitreview import GerritInfo
 from github2gerrit.models import GitHubContext
 from github2gerrit.similarity import extract_dependency_package_from_subject
+from github2gerrit.utils import reset_warning_once
 
 
 # -------------------------------------------------------------------
 # Helpers
 # -------------------------------------------------------------------
+
+
+# Dependency fixture values reused across the supersession tests.
+# Centralising them documents which data is significant to the logic under
+# test (the *package name* must match for a change to be superseded) versus
+# which is arbitrary (the exact version strings).
+_DEP_PACKAGE = "requests"
+_DEP_VERSION_OLD = "2.31.0"
+_DEP_VERSION_NEW = "2.32.0"
+_DEP_VERSION_INTERMEDIATE = "2.31.5"
+_DEP_BUMP_TITLE = (
+    f"Bump {_DEP_PACKAGE} from {_DEP_VERSION_OLD} to {_DEP_VERSION_NEW}"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_once_state() -> None:
+    """Reset the one-time warning cache before each test.
+
+    Several tests assert warn-once behaviour (for example the truncation
+    warning emitted by the anonymous fallback), which relies on process-wide
+    global state. Resetting it automatically keeps every test isolated so
+    individual tests no longer need to call ``reset_warning_once`` by hand.
+    """
+    reset_warning_once()
+
+
+def _make_change_id(seed: str) -> str:
+    """Return a valid-looking Gerrit Change-Id derived from ``seed``.
+
+    A real Gerrit Change-Id is the letter ``I`` followed by 40 hexadecimal
+    characters (a SHA-1 digest). Tests previously used mnemonic but invalid
+    values such as ``Iexist00...`` that contain non-hex characters. This
+    helper instead derives a truncated SHA-256 digest from a human-readable
+    seed: the exact hash algorithm is unimportant, it only needs to match
+    the ``I`` + 40-hex-character format while keeping failures easy to
+    trace.
+    """
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:40]
+    return f"I{digest}"
 
 
 def _gerrit_change(
@@ -202,10 +244,6 @@ class TestQueryOpenChangesByProject:
         to drive the anonymous fallback, the helper must short-circuit and
         never issue the request, returning an empty list.
         """
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         fake_client = MagicMock()
         fake_client.is_authenticated = False
 
@@ -232,10 +270,6 @@ class TestQueryOpenChangesByProject:
         The query must NOT use owner:self, and only changes whose
         GitHub-PR trailer targets the current repository are returned.
         """
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         ours = _raw_change(
             100,
             "chore: bump requests from 2.31.0 to 2.32.0",
@@ -262,10 +296,6 @@ class TestQueryOpenChangesByProject:
 
     def test_anonymous_fallback_repo_match_is_case_insensitive(self) -> None:
         """Repo trailer matching ignores case differences."""
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         ours = _raw_change(
             200,
             "chore: bump requests from 2.31.0 to 2.32.0",
@@ -283,10 +313,6 @@ class TestQueryOpenChangesByProject:
 
     def test_anonymous_fallback_matches_ghes_host(self) -> None:
         """The host is ignored, so GitHub Enterprise URLs still match."""
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         ours = _raw_change(
             210,
             "chore: bump requests from 2.31.0 to 2.32.0",
@@ -310,10 +336,6 @@ class TestQueryOpenChangesByProject:
         repo in its query string, a non-URL value, and a relative path
         (e.g. ``/org/repo/pull/1``) are all correctly excluded.
         """
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         other = _raw_change(
             220,
             "chore: bump requests from 2.31.0 to 2.32.0",
@@ -346,10 +368,6 @@ class TestQueryOpenChangesByProject:
         GitHub2Gerrit changes (which carry the GitHub-PR trailer) so busy
         projects do not truncate before the relevant changes are seen.
         """
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         fake_client = MagicMock()
         fake_client.is_authenticated = False
         fake_client.get.return_value = []
@@ -368,10 +386,6 @@ class TestQueryOpenChangesByProject:
     ) -> None:
         """Hitting the result cap emits a one-time truncation warning."""
         import logging
-
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
 
         c1 = _raw_change(
             300,
@@ -406,9 +420,6 @@ class TestQueryOpenChangesByProject:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Disabling the fallback flag skips even when repo is known."""
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
         monkeypatch.setenv("G2G_ANON_SUPERSEDE_FALLBACK", "false")
 
         fake_client = MagicMock()
@@ -422,10 +433,6 @@ class TestQueryOpenChangesByProject:
 
     def test_anonymous_fallback_whitespace_repo_skips(self) -> None:
         """A blank/whitespace-only repository must not trigger a query."""
-        from github2gerrit.utils import reset_warning_once
-
-        reset_warning_once()
-
         fake_client = MagicMock()
         fake_client.is_authenticated = False
 
@@ -446,7 +453,16 @@ class TestQueryOpenChangesByProject:
     new=lambda *_a, **_kw: "",
 )
 class TestAbandonSupersededDependencyChanges:
-    """Tests for the post-push abandon sweep."""
+    """Tests for the post-push abandon sweep.
+
+    The class-level ``@patch`` stubs
+    ``gerrit_urls._discover_base_path_for_host`` to return an empty base
+    path for *every* test method below, so URL construction does not attempt
+    host discovery (a network call). The patch is intentionally applied at
+    the class level because all methods exercise URL building; it is not
+    injected as a method argument because the stubbed value is never
+    inspected by the tests.
+    """
 
     @patch("github2gerrit.gerrit_rest.build_client_for_host")
     @patch("github2gerrit.gerrit_query.query_open_changes_by_project")
@@ -789,7 +805,7 @@ class TestStrategy5Integration:
         # Set up GitHub mocks — strategies 1-4 should all fail
         mock_get_pull.return_value = _FakePullRequest(
             number=42,
-            title="Bump requests from 2.31.0 to 2.32.0",
+            title=_DEP_BUMP_TITLE,
             user=_FakeGitHubUser(),
         )
         mock_get_repo.return_value = MagicMock()
@@ -803,10 +819,14 @@ class TestStrategy5Integration:
         mock_gerrit_client.return_value = fake_gerrit
 
         # Strategy 5 — return an open change bumping the same package
+        existing_change_id = _make_change_id("strategy5-existing")
         existing_change = _gerrit_change(
-            change_id="Iexist00000000000000000000000000000000000",
+            change_id=existing_change_id,
             number="999",
-            subject="chore: bump requests from 2.31.0 to 2.31.5",
+            subject=(
+                f"chore: bump {_DEP_PACKAGE} from "
+                f"{_DEP_VERSION_OLD} to {_DEP_VERSION_INTERMEDIATE}"
+            ),
         )
         mock_query_open.return_value = [existing_change]
 
@@ -832,7 +852,7 @@ class TestStrategy5Integration:
         )
 
         result = orch._find_existing_change_for_pr(gh, gerrit)
-        assert result == ["Iexist00000000000000000000000000000000000"]
+        assert result == [existing_change_id]
 
     @patch("github2gerrit.core.build_client")
     @patch("github2gerrit.core.get_repo_from_env")
@@ -956,7 +976,14 @@ class TestStrategy5Integration:
     new=lambda *_a, **_kw: "",
 )
 class TestRealWorldScenarios:
-    """Scenarios taken directly from the issue report."""
+    """Scenarios taken directly from the issue report.
+
+    As with :class:`TestAbandonSupersededDependencyChanges`, the class-level
+    ``@patch`` stubs ``gerrit_urls._discover_base_path_for_host`` for every
+    method so URL construction avoids host discovery. The stub uses ``new=``
+    rather than a mock argument because its return value is fixed and never
+    asserted on.
+    """
 
     @patch("github2gerrit.gerrit_rest.build_client_for_host")
     @patch("github2gerrit.gerrit_query.query_open_changes_by_project")

--- a/tests/test_gitutils_helpers.py
+++ b/tests/test_gitutils_helpers.py
@@ -16,19 +16,40 @@ from github2gerrit.gitutils import run_cmd
 from github2gerrit.gitutils import run_cmd_with_retries
 
 
+# Environment variables that pytest, pytest-cov, and pytest-xdist inject so
+# that coverage measurement and test metadata propagate into subprocesses.
+# When a test spawns the current Python interpreter via ``run_cmd`` we clear
+# these so the child does not start its own coverage run (which can emit
+# warnings or write stray data files) and so its output stays deterministic
+# regardless of how the outer pytest session was invoked.
+#
+#   COV_CORE_SOURCE/CONFIG/DATAFILE  pytest-cov subprocess coverage hooks
+#   COVERAGE_PROCESS_START           triggers coverage startup in children
+#   COVERAGE_FILE / COVERAGE_RCFILE  coverage data / config file locations
+#   PYTEST_ADDOPTS                   extra pytest args inherited by children
+#   PYTEST_CURRENT_TEST              current test id (set per test by pytest)
+#   PYTEST_XDIST_WORKER              xdist worker id when running in parallel
+_COVERAGE_ENV_KEYS = (
+    "COV_CORE_SOURCE",
+    "COV_CORE_CONFIG",
+    "COV_CORE_DATAFILE",
+    "COVERAGE_PROCESS_START",
+    "COVERAGE_FILE",
+    "COVERAGE_RCFILE",
+    "PYTEST_ADDOPTS",
+    "PYTEST_CURRENT_TEST",
+    "PYTEST_XDIST_WORKER",
+)
+
+
 def _no_cov_env() -> dict[str, str]:
-    keys = [
-        "COV_CORE_SOURCE",
-        "COV_CORE_CONFIG",
-        "COV_CORE_DATAFILE",
-        "COVERAGE_PROCESS_START",
-        "COVERAGE_FILE",
-        "COVERAGE_RCFILE",
-        "PYTEST_ADDOPTS",
-        "PYTEST_CURRENT_TEST",
-        "PYTEST_XDIST_WORKER",
-    ]
-    return dict.fromkeys(keys, "")
+    """Return an env mapping that disables coverage in subprocesses.
+
+    Every key in :data:`_COVERAGE_ENV_KEYS` is mapped to an empty string so
+    a spawned child process inherits a clean, coverage-free environment. See
+    that constant for the rationale behind each cleared variable.
+    """
+    return dict.fromkeys(_COVERAGE_ENV_KEYS, "")
 
 
 def test_mask_text_replaces_tokens_and_ignores_empty() -> None:
@@ -93,24 +114,31 @@ def test_run_cmd_with_retries_retries_on_transient_error_then_succeeds(
 
     monkeypatch.setattr("time.sleep", _fake_sleep)
 
-    # Script: on first run create a marker and exit non-zero with a transient
-    # error in stderr.
-    # On subsequent runs (marker exists) print success and exit 0.
+    # The helper script creates a marker file and fails with a transient
+    # error on its first run, then succeeds once the marker exists. Writing
+    # the behaviour to a real script file (taking the marker path as an
+    # argument) keeps the test readable and avoids embedding Python source
+    # inside an f-string.
     marker = tmp_path / "attempted"
-
-    code = f"""
-import os, sys, pathlib
-p = pathlib.Path({str(marker)!r})
-if not p.exists():
-    p.write_text("1", encoding="utf-8")
-    print("could not resolve host: example.com", file=sys.stderr)
-    sys.exit(128)
-else:
-    print("ok")
-"""
+    script = tmp_path / "transient_then_succeed.py"
+    script.write_text(
+        "import pathlib\n"
+        "import sys\n"
+        "\n"
+        "marker = pathlib.Path(sys.argv[1])\n"
+        "if not marker.exists():\n"
+        '    marker.write_text("1", encoding="utf-8")\n'
+        '    print("could not resolve host: example.com", file=sys.stderr)\n'
+        "    sys.exit(128)\n"
+        "else:\n"
+        '    print("ok")\n',
+        encoding="utf-8",
+    )
 
     res = run_cmd_with_retries(
-        [sys.executable, "-c", code], cwd=tmp_path, env=_no_cov_env()
+        [sys.executable, str(script), str(marker)],
+        cwd=tmp_path,
+        env=_no_cov_env(),
     )
     # Should succeed after retry, marker must exist, and we should have slept at
     # least once
@@ -262,6 +290,24 @@ def test_git_last_commit_trailers_parsing_edge_cases(
         "Ideadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
         "Iabc123abc123abc123abc123abc123abc123ab",
     ]
+
+
+def test_git_last_commit_trailers_returns_empty_on_git_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing ``git show`` (e.g. fresh repo) yields an empty mapping."""
+    from github2gerrit.gitutils import GitError
+    from github2gerrit.gitutils import git_last_commit_trailers
+
+    def _raise_git_error(rev: str, **_kw: object) -> str:
+        raise GitError("git show HEAD failed")
+
+    monkeypatch.setattr("github2gerrit.gitutils.git_show", _raise_git_error)
+
+    # The implementation catches GitError and returns an empty dict, both
+    # without and with a key filter.
+    assert git_last_commit_trailers() == {}
+    assert git_last_commit_trailers(keys=["Change-Id"]) == {}
 
 
 def test_git_quiet_suppresses_failure_logging(


### PR DESCRIPTION
## Summary

Applies the maintainability improvements flagged by the GitHub **Code
quality** AI review across two test modules. No production code is
changed; these are test-only quality improvements.

## `tests/test_dependency_supersession.py`

- **Replace manual `reset_warning_once()` calls with an autouse fixture.**
  The warn-once dedup cache was reset by hand in nine separate tests. A
  single module-level `autouse=True` fixture now resets it before every
  test, removing the redundant per-test imports/calls and the risk of
  forgetting to reset state in new tests.
- **Document the class-level `@patch`.** The implicit class-level patch of
  `gerrit_urls._discover_base_path_for_host` on
  `TestAbandonSupersededDependencyChanges` (and `TestRealWorldScenarios`)
  is now explained in the class docstrings.
- **Centralise fixture data into named constants.** The repeated
  `requests` / version strings are now `_DEP_PACKAGE`, `_DEP_VERSION_*`
  and `_DEP_BUMP_TITLE` constants that document which values are
  significant to the supersession logic versus which are arbitrary.
- **Add a `_make_change_id` helper.** Change-Ids such as
  `Iexist00...` contained non-hex characters. The helper derives a
  correctly formatted `I` + 40 hex-digit Change-Id from a readable seed.

## `tests/test_gitutils_helpers.py`

- **Document and extract the coverage env keys.** The keys cleared by
  `_no_cov_env()` are now a documented module-level
  `_COVERAGE_ENV_KEYS` constant explaining why each variable is cleared.
- **Replace the embedded f-string subprocess source.** The transient-retry
  test now writes its behaviour to an explicit helper script file (taking
  the marker path as an argument) instead of embedding Python source in an
  f-string.
- **Add error-path coverage for `git_last_commit_trailers`.** A new test
  exercises the `GitError` branch where `git_show` fails and the function
  returns an empty mapping.

## Validation

- `uv run pytest` — 1343 passed
- `uv run ruff check` / `ruff format --check` — clean
- `basedpyright` on both files — 0 errors, 0 warnings
- pre-commit hooks pass on commit
