### PR TITLE
Feat: Add Copilot to known automation tools

### DIFF
--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -177,6 +177,7 @@ def _check_automation_only(
 
     # Known automation tools
     known_automation_tools = [
+        "Copilot",
         "dependabot[bot]",
         "dependabot",
         "pre-commit-ci[bot]",

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -198,8 +198,8 @@ def _check_automation_only(
     # Check if author is in known automation tools list
     if pr_author not in known_automation_tools:
         log.warning(
-            "PR #%s from '%s' rejected - known automation tools "
-            "(dependabot, pre-commit-ci) required",
+            "PR #%s from '%s' rejected - only known automation tools "
+            "are accepted when AUTOMATION_ONLY is enabled",
             gh.pr_number,
             pr_author,
         )

--- a/tests/test_automation_only.py
+++ b/tests/test_automation_only.py
@@ -94,6 +94,30 @@ class TestAutomationOnly:
         # Should not raise any exception
         _check_automation_only(mock_pr, gh)
 
+    def test_copilot_pr_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Copilot PRs should be allowed when automation_only is enabled."""
+        monkeypatch.setenv("AUTOMATION_ONLY", "true")
+
+        mock_pr = MagicMock()
+        mock_pr.user.login = "Copilot"
+
+        gh = GitHubContext(
+            event_name="pull_request",
+            event_action="opened",
+            event_path=None,
+            repository="owner/repo",
+            repository_owner="owner",
+            server_url="https://github.com",
+            run_id="123",
+            sha="abc123",
+            base_ref="main",
+            head_ref="feature",
+            pr_number=1,
+        )
+
+        # Should not raise any exception
+        _check_automation_only(mock_pr, gh)
+
     @patch("github2gerrit.github_api.close_pr")
     def test_regular_user_pr_rejected(
         self, mock_close_pr: Any, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Copilot can fully generate commits and submit them as PRs, so it qualifies as an automation tool. Currently, these PRs are rejected when G2G is in "automation only" mode.