### PR TITLE
Feat: Add OpenSSF Scorecard and fix zizmor

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -14,13 +14,19 @@ on:
 
 permissions: {}
 
+# Serialise repeated runs for the same tag; never cancel an in-flight
+# release. Distinct tags use distinct groups and proceed independently.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 jobs:
   repository-metadata:
     name: "Repository Metadata"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Read repository contents (checkout, etc.)
+      pull-requests: read  # Read PR metadata for the metadata action
     timeout-minutes: 5
     steps:
       # yamllint disable-line rule:line-length
@@ -32,6 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Gather repository metadata"
         id: repo-metadata
@@ -65,6 +72,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: 'Verify pushed tag'
         id: 'tag-validate'
@@ -83,9 +91,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          STEPS_TAG_VALIDATE_OUTPUTS_TAG_NAME: ${{ steps.tag-validate.outputs.tag_name }}
         run: |
           # Ensure draft release exists
-          TAG="${{ steps.tag-validate.outputs.tag_name }}"
+          TAG="${STEPS_TAG_VALIDATE_OUTPUTS_TAG_NAME}"
           # Check if release exists and get its draft status
           if RELEASE_INFO=$(gh release view "$TAG" \
             --json isDraft 2>/dev/null); then
@@ -127,6 +136,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Build Python project'
         id: 'python-build'
@@ -156,6 +167,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Test Python project [PYTEST]'
         # yamllint disable-line rule:line-length
@@ -183,6 +196,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Audit Python project'
         # yamllint disable-line rule:line-length
@@ -207,6 +222,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Generate SBOM"
         id: sbom
@@ -270,8 +287,8 @@ jobs:
             # Grype summary
             {
               echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+              echo "SBOM count: ${STEPS_SBOM_OUTPUTS_COMPONENT_COUNT}"
+              echo "Tool used: ${STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER}"
               echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
@@ -284,6 +301,9 @@ jobs:
               echo "--- Grype scan results ---"
               cat grype-results.txt
             fi
+        env:
+          STEPS_SBOM_OUTPUTS_COMPONENT_COUNT: ${{ steps.sbom.outputs.component_count }}
+          STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER: ${{ steps.sbom.outputs.dependency_manager }}
 
       - name: "Check Grype scan results"
         if: >-
@@ -377,6 +397,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: '⬇ Download build artefacts'
         # yamllint disable-line rule:line-length
@@ -415,14 +437,17 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Check if release is already promoted'
         id: 'check-promoted'
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           if gh release view "$TAG" --json isDraft --jq '.isDraft' \
               2>/dev/null | grep -q "false"; then
             echo "Release $TAG is already promoted, skipping promotion"
@@ -449,7 +474,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
           echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -36,8 +36,8 @@ jobs:
     name: "Repository Metadata"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Read repository contents (checkout, etc.)
+      pull-requests: read  # Read PR metadata for the metadata action
     timeout-minutes: 5
     steps:
       # yamllint disable-line rule:line-length
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Gather repository metadata"
         id: repo-metadata
@@ -83,6 +84,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Build Python project'
         id: python-build
@@ -111,6 +114,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Python tests [pytest] ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
@@ -138,6 +143,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Audit dependencies ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
@@ -156,6 +163,8 @@ jobs:
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Generate SBOM"
         id: sbom
@@ -217,8 +226,8 @@ jobs:
             # Grype summary
             {
               echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+              echo "SBOM count: ${STEPS_SBOM_OUTPUTS_COMPONENT_COUNT}"
+              echo "Tool used: ${STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER}"
               echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
@@ -231,6 +240,9 @@ jobs:
               echo "--- Grype scan results ---"
               cat grype-results.txt
             fi
+        env:
+          STEPS_SBOM_OUTPUTS_COMPONENT_COUNT: ${{ steps.sbom.outputs.component_count }}
+          STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER: ${{ steps.sbom.outputs.dependency_manager }}
 
       - name: "Check Grype scan results"
         if: >-

--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -170,14 +170,15 @@ permissions: {}
 
 jobs:
   manual-dispatch:
+    name: "Manual dispatch (G2G)"
     # Manual run: allow optional PR_NUMBER (0 => process all PRs)
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
+      contents: read  # Read repository contents (checkout, etc.)
+      pull-requests: write  # Comment on and update the mirrored PR
+      issues: write  # Post status/back-reference comments on issues
     steps:
       # yamllint disable rule:line-length
       # PR_NUMBER normalization is handled by the composite action
@@ -201,14 +202,15 @@ jobs:
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
 
   github2gerrit:
+    name: "Mirror PR to Gerrit"
     # Only run if we have a proper pull request context
     if: ${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
+      contents: read  # Read repository contents (checkout, etc.)
+      pull-requests: write  # Comment on and update the mirrored PR
+      issues: write  # Post status/back-reference comments on issues
     steps:
       - name: Run github2gerrit composite action
         uses: ./

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,38 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "50 4 * * 0"
+  push:
+    branches: ["main", "master"]
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  openssf-scorecard:
+    name: "OpenSSF Scorecard"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
+    permissions:
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
+      # Uncomment the permission below if installing in a private repository.
+      # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Running local action: ${{ github.repository }}"
         uses: ./
@@ -71,6 +73,8 @@ jobs:
   cli-integration-test:
     name: 'CLI Integration Test'
     runs-on: 'ubuntu-latest'
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 15
@@ -80,6 +84,8 @@ jobs:
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Setup Python'
         # yamllint disable-line rule:line-length
@@ -121,22 +127,23 @@ jobs:
           G2G_VERBOSE: 'true'
           FETCH_DEPTH: '50'
           USE_PR_AS_COMMIT: 'true'
+          VARS_DEPENDABOT_PR_URL_1: ${{ vars.DEPENDABOT_PR_URL_1 }}
           # lfit/sandbox has correct .gitreview pointing to LF Gerrit
         run: |
           echo "Testing GitHub2Gerrit CLI integration with LF Gerrit server..."
-          echo "Target PR: ${{ vars.DEPENDABOT_PR_URL_1 }}"
+          echo "Target PR: ${VARS_DEPENDABOT_PR_URL_1}"
 
           # Install current code in development mode and test CLI directly
           echo "Installing current code: uv pip install --system -e ."
           uv pip install --system -e .
 
-          echo "Running: python -m github2gerrit.cli ${{ vars.DEPENDABOT_PR_URL_1 }}"
-          python -m github2gerrit.cli "${{ vars.DEPENDABOT_PR_URL_1 }}"
+          echo "Running: python -m github2gerrit.cli ${VARS_DEPENDABOT_PR_URL_1}"
+          python -m github2gerrit.cli "${VARS_DEPENDABOT_PR_URL_1}"
 
           echo "✅ Dry-run CLI integration test completed successfully"
           {
             echo "CLI Integration test summary:"
-            echo "- Tested with external PR: ${{ vars.DEPENDABOT_PR_URL_1 }}"
+            echo "- Tested with external PR: ${VARS_DEPENDABOT_PR_URL_1}"
             echo "- Target Gerrit: gerrit.linuxfoundation.org"
             echo "- Target Project: sandbox"
             echo "- Mode: DRY_RUN (validation only)"
@@ -167,13 +174,14 @@ jobs:
           DRY_RUN: 'true'
           CLOSE_MERGED_PRS: 'false'
           SYNC_ALL_OPEN_PRS: 'false'
+          VARS_DEPENDABOT_PR_URL_1: ${{ vars.DEPENDABOT_PR_URL_1 }}
         run: |
           echo "Testing GitHub API error handling with invalid token..."
-          echo "Target PR: ${{ vars.DEPENDABOT_PR_URL_1 }}"
+          echo "Target PR: ${VARS_DEPENDABOT_PR_URL_1}"
 
           # Capture exit code
           EXIT_CODE=0
-          python -m github2gerrit.cli "${{ vars.DEPENDABOT_PR_URL_1 }}" || EXIT_CODE=$?
+          python -m github2gerrit.cli "${VARS_DEPENDABOT_PR_URL_1}" || EXIT_CODE=$?
           echo "EXIT_CODE=$EXIT_CODE" >> "$GITHUB_ENV"
 
           # Should fail with exit code 4 (GITHUB_API_ERROR)
@@ -187,7 +195,6 @@ jobs:
       - name: 'Verify Error Handling'
         shell: bash
         run: |
-          EXIT_CODE="${{ env.EXIT_CODE }}"
           if [ "${EXIT_CODE}" -eq 4 ] 2>/dev/null; then
             echo "✅ GitHub API error handling working correctly"
             echo "## Error Handling Test ✅" >> "$GITHUB_STEP_SUMMARY"
@@ -225,11 +232,12 @@ jobs:
           G2G_VERBOSE: 'true'
           FETCH_DEPTH: '50'
           USE_PR_AS_COMMIT: 'true'
+          VARS_DEPENDABOT_PR_URL_2: ${{ vars.DEPENDABOT_PR_URL_2 }}
           # lfit/sandbox has correct .gitreview pointing to LF Gerrit
           # Force derivation to be disabled so our overrides take precedence
         run: |
           echo '🚀 Integration Test Summary'
-          echo "Target PR: https://github.com/lfit/sandbox/pull/6"
+          echo "Target PR: ${VARS_DEPENDABOT_PR_URL_2}"
 
           # Configure git with your identity
           # Gerrit private SSH key is linked to this account
@@ -238,11 +246,13 @@ jobs:
 
           # Push to Gerrit
           echo "Pushing change to Gerrit..."
-          python -m github2gerrit.cli "${{ vars.DEPENDABOT_PR_URL_2 }}"
+          python -m github2gerrit.cli "${VARS_DEPENDABOT_PR_URL_2}"
 
   action-integration-test:
     name: 'Action Integration Test'
     runs-on: 'ubuntu-latest'
+    # Dedicated environment scopes access to the Gerrit test secrets
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 15
@@ -252,6 +262,8 @@ jobs:
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Setup Python'
         # yamllint disable-line rule:line-length
@@ -288,22 +300,23 @@ jobs:
           ALLOW_DUPLICATES: 'true'
           PRESERVE_GITHUB_PRS: 'true'
           G2G_VERBOSE: 'true'
+          VARS_DEPENDABOT_PR_URL_1: ${{ vars.DEPENDABOT_PR_URL_1 }}
           # lfit/sandbox has correct .gitreview pointing to LF Gerrit
         run: |
           echo "Testing GitHub2Gerrit CLI integration with LF Gerrit server..."
-          echo "Target PR: ${{ vars.DEPENDABOT_PR_URL_1 }}"
+          echo "Target PR: ${VARS_DEPENDABOT_PR_URL_1}"
 
           # Install current code in development mode and test CLI directly
           echo "Installing current code: uv pip install --system -e ."
           uv pip install --system -e .
 
-          echo "Running: python -m github2gerrit.cli ${{ vars.DEPENDABOT_PR_URL_1 }}"
-          python -m github2gerrit.cli "${{ vars.DEPENDABOT_PR_URL_1 }}"
+          echo "Running: python -m github2gerrit.cli ${VARS_DEPENDABOT_PR_URL_1}"
+          python -m github2gerrit.cli "${VARS_DEPENDABOT_PR_URL_1}"
 
           echo "✅ Dry-run CLI integration test completed successfully"
           {
             echo "CLI Integration test summary:"
-            echo "- Tested with external PR: ${{ vars.DEPENDABOT_PR_URL_1 }}"
+            echo "- Tested with external PR: ${VARS_DEPENDABOT_PR_URL_1}"
             echo "- Target Gerrit: gerrit.linuxfoundation.org"
             echo "- Target Project: sandbox"
             echo "- Mode: DRY_RUN (validation only)"
@@ -337,11 +350,12 @@ jobs:
           G2G_VERBOSE: 'true'
           FETCH_DEPTH: '50'
           USE_PR_AS_COMMIT: 'true'
+          VARS_DEPENDABOT_PR_URL_2: ${{ vars.DEPENDABOT_PR_URL_2 }}
           # lfit/sandbox has correct .gitreview pointing to LF Gerrit
           # Force derivation to be disabled so our overrides take precedence
         run: |
           echo '🚀 Action Integration Test Summary'
-          echo "Target PR: ${{ vars.DEPENDABOT_PR_URL_2 }}"
+          echo "Target PR: ${VARS_DEPENDABOT_PR_URL_2}"
 
           # Configure git with your identity
           # Gerrit private SSH key is linked to this account
@@ -350,4 +364,4 @@ jobs:
 
           # Push to Gerrit
           echo "Pushing change to Gerrit..."
-          python -m github2gerrit.cli "${{ vars.DEPENDABOT_PR_URL_2 }}"
+          python -m github2gerrit.cli "${VARS_DEPENDABOT_PR_URL_2}"


### PR DESCRIPTION
## Summary

Brings `github2gerrit-action` in line with the rest of the
`lfreleng-actions` organisation for supply-chain scanning:

- **Adds the OpenSSF Scorecard reusable workflow**
  (`.github/workflows/openssf-scorecard.yaml`), pinned to
  `lfit/releng-reusable-workflows` **v0.7.2**
  (commit `fd3c1b43bc919e9e70787b009ffa2768ddbb1267`). This
  reusable keeps `harden-runner` in block mode with a curated,
  Scorecard-compatible egress allow-list (including `api.deps.dev`),
  so it satisfies the upstream `ossf/scorecard-action` workflow
  restrictions and publishes results cleanly.
- **Clears all zizmor findings up to the `auditor` persona** across the
  existing workflows:
  - Pin-safe template-injection fixes — context expansions moved
    into step `env:` vars and referenced as `${VAR}` (no action
    pins changed).
  - `persist-credentials: false` on checkout steps (no step relies
    on the persisted token; Gerrit pushes use explicit SSH identity).
  - Inline permission comments and named jobs.
  - Concurrency guard on the release workflow.
  - Removed a redundant `EXIT_CODE="${EXIT_CODE}"` self-assignment
    introduced by the automated fix (shellcheck SC2269).
  - **secrets-outside-env**: scope the Gerrit test secrets to the
    existing dedicated `development` environment on the two
    integration-test jobs in `testing.yaml` (`cli-integration-test`
    and `action-integration-test`). These jobs only run on
    `workflow_dispatch` / push to `main`, so the environment gate
    does not affect PR CI.

## Validation

- `zizmor --persona=auditor .github/workflows/` → **No findings to
  report** (also clean at `--persona=pedantic`).
- `prek run` → actionlint, yamllint, reuse, workflow validators all
  pass. (The `pytest` hook fails only on an unrelated SSH-agent
  integration test that requires a live agent; no code changes here.)

New file uses the current year (2026) in its SPDX header.
