### PR TITLE
Fix(deps): Remove uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,21 +273,6 @@ reportUnsupportedDunderAll = "error"
 
 
 [tool.uv]
-# Supply-chain cooldown: do not resolve anything published in the last
-# 7 days (rolling window; uv records it as a relative span in uv.lock).
-# Requires uv >= 0.9.17 for the relative-duration ("7 days") form.
-exclude-newer = "7 days"
-# cryptography bundles OpenSSL directly in its wheels, so OpenSSL security
-# fixes are delivered as new cryptography releases. Exempt it from the
-# supply-chain cooldown above so those patches are not held back by the
-# rolling window.
-#
-# Added 2026-06-15 to unblock GHSA-537c-gmf6-5ccf ("Vulnerable OpenSSL
-# included in cryptography wheels"; no CVE assigned), fixed in 48.0.1,
-# which the 7-day cooldown was excluding. References:
-#   https://github.com/advisories/GHSA-537c-gmf6-5ccf
-#   https://openssl-library.org/news/secadv/20260609.txt
-exclude-newer-package = { cryptography = "0 days" }
 # uv will manage installation based on this pyproject and lockfile.
 # No extra settings are required here; this stanza reserves the
 # namespace for future use if needed.

--- a/uv.lock
+++ b/uv.lock
@@ -6,13 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-cryptography = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
## Summary

The relative `exclude-newer = "7 days"` cooldown in `[tool.uv]` is baked
into `uv.lock` as `exclude-newer-span = "P7D"`. Dependabot's `uv` updater
re-resolves against that rolling window, regenerates a byte-identical
lockfile, and fails with **"Dependency file content did not change"** —
blocking automated and priority security updates.

## Change

- Remove the `exclude-newer` supply-chain cooldown from `pyproject.toml`
  (the `[tool.uv]` table and `managed = true` are preserved).
- Also drop the now-redundant `exclude-newer-package = { cryptography =
  "0 days" }` exemption, which only existed to carve `cryptography` out
  of the cooldown being removed here (the underlying OpenSSL fix is long
  since in the normal resolution).
- Regenerate `uv.lock` (drops the `[options]` `exclude-newer-span` block);
  deletion-only, no dependency versions moved.

The supply-chain auditing tool that originally recommended this cooldown
has updated its guidance — Dependabot cooldowns now cover the same
concern without breaking priority security fixes.

## Validation

- `uv lock` regenerates cleanly.
- `pre-commit` (including the test suite) passes.