### PR TITLE
Chore: Remove AI-slop comments flagged by aislop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,10 +200,6 @@ module = ["typer", "typer.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["importlib_metadata"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = ["pytest", "pytest.*"]
 ignore_missing_imports = true
 

--- a/src/github2gerrit/cli.py
+++ b/src/github2gerrit/cli.py
@@ -88,15 +88,10 @@ from .utils import parse_bool_env
 
 
 def get_version(package: str) -> str:
-    """Get package version, trying importlib.metadata first, then fallback."""
-    try:
-        from importlib.metadata import version as stdlib_version
+    """Get the installed package version via importlib.metadata."""
+    from importlib.metadata import version
 
-        return str(stdlib_version(package))
-    except ImportError:
-        from importlib_metadata import version as backport_version
-
-        return str(backport_version(package))
+    return str(version(package))
 
 
 # Legacy error handling functions - now use centralized error_codes module
@@ -184,7 +179,6 @@ def _check_automation_only(
         "pre-commit-ci",
     ]
 
-    # Get PR author
     pr_author = getattr(getattr(pr_obj, "user", None), "login", "")
     if not pr_author:
         log.warning("Unable to determine PR author, allowing PR to proceed")
@@ -262,10 +256,8 @@ def _extract_and_display_pr_info(
         # Check if automation_only is enabled and reject non-automation PRs
         _check_automation_only(pr_obj, gh, progress_tracker)
 
-        # Extract PR information
         title, _body = get_pr_title_body(pr_obj)
 
-        # Get additional PR details
         pr_info = {
             "Repository": gh.repository,
             "PR Number": gh.pr_number,
@@ -364,7 +356,6 @@ def _parse_github_target(url: str) -> GitHubPRTarget | GitHubRepoTarget:
 
     owner, repo = parts[0], parts[1]
 
-    # Check for PR URL
     if len(parts) >= 4 and parts[2] in ("pull", "pulls"):
         try:
             pr_number = int(parts[3])
@@ -377,7 +368,6 @@ def _parse_github_target(url: str) -> GitHubPRTarget | GitHubRepoTarget:
 
 
 APP_NAME = "github2gerrit"
-
 
 if TYPE_CHECKING:
     BaseGroup = object
@@ -429,10 +419,8 @@ def _resolve_issue_id_from_json(json_str: str, github_actor: str) -> str:
         return ""
 
     try:
-        # Parse JSON
         lookup_data = json.loads(json_str)
 
-        # Validate it's an array
         if not isinstance(lookup_data, list):
             log.warning(
                 "⚠️ Warning: Issue-ID JSON was not valid (expected array)"
@@ -484,8 +472,11 @@ def _print_version_banner() -> None:
     try:
         app_version = get_version("github2gerrit")
         print(f"🏷️  github2gerrit version {app_version}")
-    except Exception:
-        print("⚠️  github2gerrit version information not available")
+    # The banner is cosmetic: a missing or unreadable package version
+    # must never block CLI startup.
+    # aislop-ignore-next-line swallowed-exception
+    except Exception as exc:
+        print(f"⚠️  github2gerrit version information not available: {exc}")
 
 
 # Show version information when --help is used or in GitHub Actions mode
@@ -531,7 +522,6 @@ def _save_derived_parameters_after_success(data: Inputs) -> None:
     """Save derived parameters to config file after successful Gerrit
     submission."""
     try:
-        # Get the organization used for derivation
         org_for_cfg = (
             data.organization
             or os.getenv("ORGANIZATION")
@@ -756,8 +746,6 @@ def main(
         envvar="G2G_SHOW_PROGRESS",
         help="Show real-time progress updates with Rich formatting.",
     ),
-    # BREAKING CHANGE v0.2.0: Default changed from True to False
-    # for more flexible commit reconciliation
     similarity_files: bool = typer.Option(
         False,
         "--similarity-files/--no-similarity-files",
@@ -852,7 +840,6 @@ def main(
     - No arguments: environment variables determine behaviour (CI/CD mode)
     """
 
-    # Handle version flag first
     if version_flag:
         try:
             app_version = get_version("github2gerrit")
@@ -931,7 +918,6 @@ def main(
 
     # Handle netrc credential loading if enabled
     if not no_netrc:
-        # Get the Gerrit server from environment or CLI
         gerrit_host = gerrit_server or os.getenv("GERRIT_SERVER", "")
         if gerrit_host:
             try:
@@ -963,21 +949,18 @@ def main(
                 safe_typer_echo(f"❌ Failed to parse .netrc file: {e}")
                 sys.exit(int(ExitCode.CONFIGURATION_ERROR))
 
-    # Set up logging level based on verbose flag
     if verbose:
         os.environ["G2G_LOG_LEVEL"] = "DEBUG"
         _reconfigure_logging()
 
-    # Initialize Rich-aware logging system
     setup_rich_aware_logging()
 
-    # Log version to logs in GitHub Actions environment
     if _is_github_actions_context():
         try:
             app_version = get_version("github2gerrit")
             log.debug("github2gerrit version %s", app_version)
-        except Exception:
-            log.warning("Version information not available")
+        except Exception as exc:
+            log.warning("Version information not available: %s", exc)
 
     # Show initial progress if Rich is available and progress is enabled
     if show_progress and not RICH_AVAILABLE:
@@ -1041,7 +1024,6 @@ def main(
     if reuse_strategy:
         os.environ["REUSE_STRATEGY"] = reuse_strategy
 
-    # Validate similarity parameters
     if not (0.0 <= similarity_subject <= 1.0):
         msg = (
             f"similarity_subject must be between 0.0 and 1.0, "
@@ -1231,7 +1213,6 @@ def _build_inputs_from_env() -> Inputs:
 
 
 def _process_bulk(data: Inputs, gh: GitHubContext) -> bool:
-    # Initialize progress tracker for processing
     show_progress = env_bool("G2G_SHOW_PROGRESS", True)
     target = gh.repository
 
@@ -1303,7 +1284,6 @@ def _process_bulk(data: Inputs, gh: GitHubContext) -> bool:
             gh.event_action,
         )
 
-        # Update progress tracker for this PR
         progress_tracker.update_operation(f"Processing PR #{pr_number}...")
         progress_tracker.pr_processed()
 
@@ -1391,7 +1371,6 @@ def _process_bulk(data: Inputs, gh: GitHubContext) -> bool:
         )
         pr_tasks.append((pr, per_ctx))
 
-    # Process PRs in parallel
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         log.debug(
             "Processing %d PRs with %d parallel workers",
@@ -1495,7 +1474,6 @@ def _process_bulk(data: Inputs, gh: GitHubContext) -> bool:
         }
     )
 
-    # Stop progress tracker and show final results
     if failed_count == 0:
         progress_tracker.update_operation("Processing completed ✅")
     else:
@@ -1544,7 +1522,6 @@ def _process_single(
     gh: GitHubContext,
     progress_tracker: G2GProgressTracker | DummyProgressTracker | None = None,
 ) -> tuple[bool, SubmissionResult]:
-    # Create temporary directory for all git operations
     with tempfile.TemporaryDirectory() as temp_dir:
         workspace = Path(temp_dir)
 
@@ -1770,7 +1747,6 @@ def _process_single(
 
 
 def _load_effective_inputs() -> Inputs:
-    # Build inputs from environment (used by URL callback path)
     data = _build_inputs_from_env()
 
     # Detect GitHub CI mode and configure accordingly
@@ -1789,7 +1765,6 @@ def _load_effective_inputs() -> Inputs:
     )
     cfg = load_org_config(org_for_cfg)
 
-    # Get repository for GERRIT_PROJECT derivation
     repository = os.getenv("GITHUB_REPOSITORY", "")
 
     # Apply dynamic parameter derivation for missing Gerrit parameters
@@ -1939,7 +1914,6 @@ def _process_close_gerrit_change(
     # Check if close_merged_prs is enabled
     close_merged_prs = env_bool("CLOSE_MERGED_PRS", True)
 
-    # Check Gerrit change status
     status = check_gerrit_change_status(gerrit_change_url)
 
     # Validate status: without --force, reject MERGED/ABANDONED changes
@@ -1956,7 +1930,9 @@ def _process_close_gerrit_change(
             error_msg,
         )
 
-    # Log status information
+    # Branches vary in log level and nested close_merged_prs handling,
+    # so a dispatch table would obscure this status logging.
+    # aislop-ignore-next-line python-repetitive-dispatch
     if status == "ABANDONED":
         if close_merged_prs:
             log.debug(
@@ -1983,7 +1959,6 @@ def _process_close_gerrit_change(
 
     log.debug("Found GitHub PR URL: %s", pr_url)
 
-    # Parse PR URL to get owner info for auto-discovery
     parsed = parse_pr_url(pr_url)
     if not parsed:
         log.error("Failed to parse PR URL: %s", pr_url)
@@ -2007,6 +1982,9 @@ def _process_close_gerrit_change(
             progress_tracker=None,
             close_merged_prs=close_merged_prs,
         )
+    # log.exception records the caught error and traceback; keep
+    # processing so one PR failure cannot abort the remaining closures.
+    # aislop-ignore-next-line silent-recovery
     except Exception:
         log.exception("Failed to close GitHub PR #%d", pr_number)
 
@@ -2028,7 +2006,6 @@ def _process_close_merged_prs(data: Inputs, gh: GitHubContext) -> None:
     """
     log.info("🔄 Processing merged Gerrit changes to close GitHub PRs")
 
-    # Initialize progress tracker
     show_progress = env_bool("G2G_SHOW_PROGRESS", True)
     target = gh.repository
 
@@ -2054,7 +2031,6 @@ def _process_close_merged_prs(data: Inputs, gh: GitHubContext) -> None:
                 with gh.event_path.open() as f:
                     event_payload = json.load(f)
 
-                # Extract commit SHAs from the push event
                 if "commits" in event_payload:
                     commit_shas = [
                         commit["id"]
@@ -2141,7 +2117,6 @@ def _process_close_merged_prs(data: Inputs, gh: GitHubContext) -> None:
 def _process() -> None:
     data = _load_effective_inputs()
 
-    # Validate inputs
     try:
         _validate_inputs(data)
     except ConfigurationError as exc:
@@ -2151,11 +2126,11 @@ def _process() -> None:
 
     gh = _read_github_context()
 
-    # --- G2G_NO_GERRIT: leverage DRY_RUN infrastructure ---
-    # G2G_NO_GERRIT reuses the existing DRY_RUN + G2G_DRYRUN_DISABLE_NETWORK
-    # code paths so that all tool logic runs but Gerrit network operations
-    # are no-ops.  Cleanup tasks (abandoned-PR / Gerrit-change sweeps) are
-    # also suppressed because they would hit a non-existent server.
+    # G2G_NO_GERRIT reuses the existing DRY_RUN +
+    # G2G_DRYRUN_DISABLE_NETWORK code paths so that all tool logic runs
+    # but Gerrit network operations are no-ops. Cleanup tasks
+    # (abandoned-PR / Gerrit-change sweeps) are also suppressed because
+    # they would hit a non-existent server.
     no_gerrit = env_bool("G2G_NO_GERRIT", False)
 
     if no_gerrit:
@@ -2336,7 +2311,6 @@ def _process() -> None:
     # 2. Direct Gerrit change URL provided in CLI
     # 3. Gerrit event dispatched via workflow_dispatch (GERRIT_CHANGE_URL set)
 
-    # Check for Gerrit event inputs from workflow_dispatch
     gerrit_event_change_url = os.getenv("GERRIT_CHANGE_URL")
     gerrit_event_type = os.getenv("GERRIT_EVENT_TYPE")
 
@@ -2469,7 +2443,6 @@ def _process() -> None:
     ):
         bulk_success = _process_bulk(data, gh)
 
-        # Log external API metrics summary
         try:
             log_api_metrics_summary()
         except Exception as exc:
@@ -2702,7 +2675,6 @@ def _process() -> None:
             # Don't fail the whole pipeline if cleanup fails
             log.warning("Gerrit cleanup failed: %s", exc)
 
-    # Log external API metrics summary
     try:
         log_api_metrics_summary()
     except Exception as exc:
@@ -2911,7 +2883,6 @@ def _validate_inputs(data: Inputs) -> None:
                 _MSG_MISSING_REQUIRED_INPUT.format(field_name=field_name)
             )
 
-    # Validate fetch depth is a positive integer
     if data.fetch_depth <= 0:
         log.error("Invalid FETCH_DEPTH: %s", data.fetch_depth)
         raise ConfigurationError(_MSG_INVALID_FETCH_DEPTH)

--- a/src/github2gerrit/commit_normalization.py
+++ b/src/github2gerrit/commit_normalization.py
@@ -149,7 +149,6 @@ class CommitNormalizer:
         if self._is_conventional_commit(title):
             return False
 
-        # Check for automation patterns
         return self._is_automation_pr(title, author)
 
     def normalize_commit_title(self, title: str, author: str) -> str:
@@ -165,7 +164,6 @@ class CommitNormalizer:
         # Determine the appropriate conventional commit type
         commit_type = self._determine_commit_type(title, author)
 
-        # Clean and normalize the title
         normalized_title = self._clean_title(title)
 
         # Apply conventional commit format
@@ -181,7 +179,6 @@ class CommitNormalizer:
 
     def _is_automation_pr(self, title: str, author: str) -> bool:
         """Check if this is an automation PR that should be normalized."""
-        # Check for known automation authors
         automation_authors = [
             "dependabot[bot]",
             "dependabot-preview[bot]",
@@ -195,7 +192,6 @@ class CommitNormalizer:
         ):
             return True
 
-        # Check for automation patterns in title
         automation_patterns = [
             r"^bump\s+",
             r"^update\s+.*\s+from\s+.*\s+to\s+",
@@ -216,10 +212,8 @@ class CommitNormalizer:
             self.workspace,
         )
 
-        # Check .pre-commit-config.yaml
         self._check_precommit_config()
 
-        # Check .github/release-drafter.yml
         self._check_release_drafter_config()
 
         # Analyze git history
@@ -239,12 +233,10 @@ class CommitNormalizer:
 
             ci_config = config.get("ci", {})
 
-            # Check autofix commit message
             autofix_msg = ci_config.get("autofix_commit_msg", "")
             if autofix_msg:
                 self._extract_preferences_from_message(autofix_msg)
 
-            # Check autoupdate commit message
             autoupdate_msg = ci_config.get("autoupdate_commit_msg", "")
             if autoupdate_msg:
                 self._extract_preferences_from_message(autoupdate_msg)
@@ -272,7 +264,6 @@ class CommitNormalizer:
                     titles = rule.get("title", [])
 
                     for title_pattern in titles:
-                        # Extract conventional commit type from pattern
                         if title_pattern.startswith(
                             "/"
                         ) and title_pattern.endswith("/i"):
@@ -292,7 +283,6 @@ class CommitNormalizer:
     def _analyze_git_history(self) -> None:
         """Analyze recent git history for conventional commit patterns."""
         try:
-            # Get recent commit messages
             git_cmd = shutil.which("git")
             if not git_cmd:
                 log.debug("git command not found in PATH")
@@ -332,7 +322,6 @@ class CommitNormalizer:
                                 1
                             )
 
-            # Update preferences based on analysis
             if type_counts:
                 # Determine most common capitalization
                 if capitalization_examples:
@@ -344,7 +333,6 @@ class CommitNormalizer:
                     else:
                         self.preferences.capitalization = "lower"
 
-                # Update preferred types
                 for commit_type in type_counts:
                     if commit_type in CONVENTIONAL_COMMIT_TYPES:
                         self.preferences.preferred_types[commit_type] = (
@@ -374,13 +362,11 @@ class CommitNormalizer:
         """Determine the appropriate conventional commit type."""
         title_lower = title.lower()
 
-        # Check for dependabot patterns first
         if "dependabot" in author.lower() or any(
             re.search(pattern, title_lower) for pattern in DEPENDABOT_PATTERNS
         ):
             return self.preferences.dependency_type
 
-        # Check for pre-commit.ci patterns
         if "pre-commit" in author.lower() or "pre-commit" in title_lower:
             return self.preferences.automation_type
 
@@ -395,10 +381,8 @@ class CommitNormalizer:
 
     def _clean_title(self, title: str) -> str:
         """Clean and normalize the title text."""
-        # Remove markdown links
         title = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title)
 
-        # Remove trailing ellipsis
         title = re.sub(r"\s*[.]{3,}.*$", "", title)
 
         # Remove markdown bold/code formatting but preserve underscores

--- a/src/github2gerrit/commit_rules.py
+++ b/src/github2gerrit/commit_rules.py
@@ -72,10 +72,6 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Data classes
-# ---------------------------------------------------------------------------
-
 # Valid values for CommitRule.location
 VALID_LOCATIONS = frozenset({"trailer", "body"})
 
@@ -135,11 +131,6 @@ class ResolvedCommitRules:
             if rule.key == key:
                 return rule.value
         return None
-
-
-# ---------------------------------------------------------------------------
-# Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_rule_entry(
@@ -230,11 +221,6 @@ def _parse_rules_list(
     return rules
 
 
-# ---------------------------------------------------------------------------
-# Top-level JSON parsing
-# ---------------------------------------------------------------------------
-
-
 @dataclass
 class CommitRulesConfig:
     """Parsed representation of the full ``COMMIT_RULES_JSON`` document."""
@@ -314,11 +300,6 @@ def parse_commit_rules_json(json_str: str) -> CommitRulesConfig | None:
     return config
 
 
-# ---------------------------------------------------------------------------
-# Resolution
-# ---------------------------------------------------------------------------
-
-
 def resolve_rules(
     config: CommitRulesConfig | None,
     *,
@@ -378,11 +359,6 @@ def resolve_rules(
         )
 
     return result
-
-
-# ---------------------------------------------------------------------------
-# Application helpers
-# ---------------------------------------------------------------------------
 
 
 def apply_body_rules(

--- a/src/github2gerrit/config.py
+++ b/src/github2gerrit/config.py
@@ -304,8 +304,8 @@ def _load_ini(path: Path) -> configparser.RawConfigParser:
 
         preprocessed = "\n".join(out_lines) + ("\n" if out_lines else "")
         cp.read_string(preprocessed)
-    except FileNotFoundError:
-        log.debug("Config file not found: %s", path)
+    except FileNotFoundError as exc:
+        log.debug("Config file not found: %s (%s)", path, exc)
     except Exception as exc:
         log.warning("Failed to read config file %s: %s", path, exc)
     return cp
@@ -600,7 +600,6 @@ def apply_parameter_derivation(
     if not organization:
         return cfg
 
-    # Check execution context to determine derivation strategy
     is_github_actions = _is_github_actions_context()
     enable_derivation = os.getenv(
         "G2G_ENABLE_DERIVATION", "true"
@@ -711,7 +710,6 @@ def save_derived_parameters_to_config(
             )
             return
 
-        # Parse existing content using configparser
         cp = _load_ini(config_file)
 
         # Find or create the organization section
@@ -730,7 +728,6 @@ def save_derived_parameters_to_config(
 
         # Only write if we added parameters
         if params_added:
-            # Write the updated configuration
             with config_file.open("w", encoding="utf-8") as f:
                 cp.write(f)
 

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -74,6 +74,7 @@ from .models import Inputs
 from .pr_content_filter import filter_pr_body
 from .reconcile_matcher import LocalCommit
 from .reconcile_matcher import create_local_commit
+from .rich_display import safe_console_print
 from .ssh_common import merge_known_hosts_content
 from .utils import env_bool
 from .utils import is_verbose_mode
@@ -99,9 +100,7 @@ except ImportError:
         SSHAgentManager = None
         setup_ssh_agent_auth = None
 
-
 log = logging.getLogger("github2gerrit.core")
-
 
 # Error message constants to comply with TRY003
 _MSG_MISSING_PR_CONTEXT = "missing PR context"
@@ -112,7 +111,6 @@ _MSG_MISSING_GERRIT_SERVER = (
 )
 _MSG_MISSING_GERRIT_PROJECT = "missing GERRIT_PROJECT"
 _MSG_DNS_RESOLUTION_FAILED = "DNS resolution failed for '%s'"
-
 
 # Removed _insert_issue_id_into_commit_message - dead code
 # All commit message building now uses _build_commit_message_with_trailers
@@ -132,7 +130,6 @@ def _clean_ellipses_from_message(message: str) -> str:
         if stripped == "..." or stripped == "…":
             continue
 
-        # Remove trailing ellipses from lines
         cleaned_line = re.sub(r"\s*\.{3,}\s*$", "", line)
         cleaned_line = re.sub(r"\s*…\s*$", "", cleaned_line)
         cleaned_lines.append(cleaned_line)
@@ -158,9 +155,7 @@ def _clean_squash_title_line(title_line: str | None) -> str:
     if not title_line:
         return ""
 
-    # Remove markdown links
     title_line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title_line)
-    # Remove trailing ellipsis/truncation
     title_line = re.sub(r"\s*[.]{3,}.*$", "", title_line)
     # Split on common separators to avoid leaking body content
     for separator in [". Bumps ", " Bumps ", ". - ", " - "]:
@@ -225,11 +220,6 @@ def _clean_squash_title_line(title_line: str | None) -> str:
         # leakage.
 
     return title_line
-
-
-# ---------------------
-# Utility functions
-# ---------------------
 
 
 def _match_first_group(pattern: str, text: str) -> str | None:
@@ -414,7 +404,6 @@ class Orchestrator:
             existing_trailers = ""
 
             if current_change:
-                # Extract current commit message
                 rev = str(current_change.get("current_revision") or "")
                 revisions = current_change.get("revisions") or {}
                 if rev and rev in revisions:
@@ -473,7 +462,6 @@ class Orchestrator:
                                 existing_trailers = "\n".join(lines[i:])
                                 break
 
-            # Build new commit message preserving metadata and trailers
             if title and description:
                 new_message = f"{title}\n\n{description}"
             elif title:
@@ -541,7 +529,6 @@ class Orchestrator:
             return
 
         try:
-            # Get PR title and body
             client = build_client()
             repo = get_repo_from_env(client)
             pr_obj = get_pull(repo, int(gh.pr_number))
@@ -580,7 +567,6 @@ class Orchestrator:
                     log.debug("PR title: %s", pr_title)
                     log.debug("Gerrit subject: %s", gerrit_subject)
 
-                    # Update with PR title and body
                     self._update_gerrit_change_metadata(
                         gerrit=gerrit,
                         change_id=change_id,
@@ -655,7 +641,6 @@ class Orchestrator:
                     current_revision = change.get("current_revision", "")
                     revisions = change.get("revisions", {})
 
-                    # Get patchset number
                     patchset_num = 0
                     if current_revision and current_revision in revisions:
                         patchset_num = revisions[current_revision].get(
@@ -676,7 +661,6 @@ class Orchestrator:
                         }
                     )
 
-                    # Log detailed info
                     if patchset_num > 1:
                         log.debug(
                             "✅ Verified %s: Change %s, patchset %d, status=%s",
@@ -772,7 +756,6 @@ class Orchestrator:
 
         change_ids: list[str] = []
 
-        # Build expected metadata for matching
         expected_pr_url = f"{gh.server_url}/{gh.repository}/pull/{gh.pr_number}"
         meta_trailers = self._build_pr_metadata_trailers(gh)
         expected_github_hash = ""
@@ -800,7 +783,6 @@ class Orchestrator:
 
             log.debug("Querying Gerrit for topic: %s", topic)
 
-            # Build client using centralized URL builder
             from .gerrit_rest import build_client_for_host
 
             client = build_client_for_host(gerrit.host)
@@ -893,7 +875,6 @@ class Orchestrator:
             mapping = parse_mapping_comments(comment_bodies)
 
             if mapping and mapping.change_ids:
-                # Validate consistency
                 from .mapping_comment import validate_mapping_consistency
 
                 if validate_mapping_consistency(
@@ -1203,7 +1184,6 @@ class Orchestrator:
         if resolved_rules.has_rules:
             base_body = apply_body_rules(base_body, resolved_rules)
 
-        # Build trailers in proper order
         trailers_ordered: list[str] = []
 
         # 0. Custom trailer-location commit rules
@@ -1233,7 +1213,9 @@ class Orchestrator:
                 log.debug(
                     "✅ Added Issue-ID %s to commit message", issue_id_value
                 )
-                print(f"✅ Added Issue-ID {issue_id_value} to commit message")
+                safe_console_print(
+                    f"✅ Added Issue-ID {issue_id_value} to commit message"
+                )
         elif preserve_existing and "Issue-ID" in existing_trailers:
             # Preserve existing Issue-ID
             for issue_id_val in existing_trailers["Issue-ID"]:
@@ -1347,7 +1329,6 @@ class Orchestrator:
             repo = get_repo_from_env(client)
             pr_obj = get_pull(repo, int(gh_context.pr_number))
 
-            # Build metadata
             mode_str = "multi-commit" if multi else "squash"
             meta = self._build_pr_metadata_trailers(gh_context)
             gh_hash = ""
@@ -1388,11 +1369,9 @@ class Orchestrator:
                     [c.body or "" for c in comments]
                 )
                 if comment_indices:
-                    # Update the latest mapping comment
                     latest_idx = comment_indices[-1]
                     latest_comment = comments[latest_idx]
 
-                    # Create new mapping for update
                     new_mapping = ChangeIdMapping(
                         pr_url=pr_url,
                         mode=mode_str,
@@ -1427,10 +1406,6 @@ class Orchestrator:
                 getattr(gh_context, "pr_number", "?"),
                 exc,
             )
-
-    # ------------------------------------------------------------------
-    # Create-missing fallback helpers
-    # ------------------------------------------------------------------
 
     def _should_create_missing(
         self,
@@ -1743,7 +1718,6 @@ class Orchestrator:
         branch = self._resolve_target_branch()
         base_ref = f"origin/{branch}"
 
-        # Get commit range: commits in HEAD not in base branch
         try:
             # Ensure workspace is prepared (consolidated git fetch)
             self._ensure_workspace_prepared(branch)
@@ -1767,19 +1741,16 @@ class Orchestrator:
 
         for index, commit_sha in enumerate(commit_list):
             try:
-                # Get commit subject
                 subject = run_cmd(
                     ["git", "show", "-s", "--pretty=format:%s", commit_sha],
                     cwd=self.workspace,
                 ).stdout.strip()
 
-                # Get full commit message
                 commit_message = run_cmd(
                     ["git", "show", "-s", "--pretty=format:%B", commit_sha],
                     cwd=self.workspace,
                 ).stdout
 
-                # Get modified files
                 files_output = run_cmd(
                     [
                         "git",
@@ -1795,7 +1766,6 @@ class Orchestrator:
                     f.strip() for f in files_output.splitlines() if f.strip()
                 ]
 
-                # Create LocalCommit object
                 local_commit = create_local_commit(
                     index=index,
                     sha=commit_sha,
@@ -1847,10 +1817,6 @@ class Orchestrator:
         self._prepared_branch: str | None = None
         # Track git-review setup state to avoid redundant setup
         self._git_review_initialized: bool = False
-
-    # ---------------
-    # Public API
-    # ---------------
 
     def validate_gerrit_server(self, gerrit_host: str | None) -> None:
         """Validate that the Gerrit server hostname can be resolved via DNS.
@@ -1988,8 +1954,6 @@ class Orchestrator:
 
         self._configure_git(gerrit, inputs)
 
-        # Phase 3: Robust reconciliation with multi-pass matching
-        # For UPDATE operations, enforce finding existing changes
         forced_reuse_ids: list[str] = []
         if is_update_operation or is_edit_operation:
             log.debug("🔍 Searching for existing Gerrit change(s) to update...")
@@ -2010,7 +1974,6 @@ class Orchestrator:
                 if not should_create:
                     raise  # propagate the original error
 
-                # --- Fall back to CREATE mode ---
                 log.warning(
                     "🔄 Falling back from UPDATE → CREATE for PR #%s "
                     "(create-missing authorised)",
@@ -2025,14 +1988,10 @@ class Orchestrator:
                 # Notify on the PR that we are creating from scratch
                 self._post_create_missing_notice(gh)
 
-        # Optimization: Determine reuse Change-IDs BEFORE preparing commits.
-        # This avoids redundant preparation calls - previously we prepared
-        # commits once initially, then if reuse_ids were found, we prepared
-        # them again, discarding the first preparation's work. Now we determine
-        # reuse_ids first, then prepare commits only once with the correct IDs.
+        # Determine reuse Change-IDs before preparing commits so the
+        # preparation step runs only once, with the correct IDs.
         reuse_ids: list[str] = []
         if inputs.submit_single_commits:
-            # Extract local commits for multi-commit reconciliation
             local_commits = self._extract_local_commits_for_reconciliation(
                 inputs, gh
             )
@@ -2123,7 +2082,6 @@ class Orchestrator:
 
         self._comment_on_pull_request(gh, gerrit, result)
 
-        # Validate that no unexpected files were committed
         self._validate_committed_files(gh, result)
 
         # Post-push supersession sweep (Option A fallback).
@@ -2176,10 +2134,6 @@ class Orchestrator:
         self._cleanup_ssh()
         return result
 
-    # ---------------
-    # Step scaffolds
-    # ---------------
-
     def _guard_pull_request_context(self, gh: GitHubContext) -> None:
         if gh.pr_number is None:
             raise OrchestratorError(_MSG_MISSING_PR_CONTEXT)
@@ -2203,7 +2157,6 @@ class Orchestrator:
         """
         from .gitreview import parse_gitreview
 
-        # --- Strategy 1: local file ---
         if path.exists():
             # Read file with explicit error handling so IO failures
             # produce a distinct message from malformed content.
@@ -2226,7 +2179,6 @@ class Orchestrator:
 
         log.info(".gitreview not found locally; attempting remote fetch")
 
-        # --- Strategy 2: GitHub API (PyGithub) ---
         repo_obj: Any | None = None
         try:
             client = build_client()
@@ -2659,7 +2611,6 @@ class Orchestrator:
                 "SSH agent setup failed, falling back to file-based SSH: %s",
                 exc,
             )
-            # Clean up any partial SSH agent setup before fallback
             if self._ssh_agent_manager:
                 self._ssh_agent_manager.cleanup()
                 self._ssh_agent_manager = None
@@ -2746,7 +2697,6 @@ class Orchestrator:
 
         log.debug("SSH key file created successfully: %s", key_path)
 
-        # Write known hosts to tool-specific location
         known_hosts_path = tool_ssh_dir / "known_hosts"
         with open(known_hosts_path, "w", encoding="utf-8") as f:
             f.write(effective_known_hosts.strip() + "\n")
@@ -3165,7 +3115,6 @@ class Orchestrator:
             start_point,
         )
 
-        # Step 1: Try deepening first (cheaper than full unshallow)
         if self._deepen_repository(depth=100):
             log.debug("Retrying checkout after deepening...")
             try:
@@ -3178,7 +3127,6 @@ class Orchestrator:
                 log.info("Checkout succeeded after deepening repository")
                 return
 
-        # Step 2: Full unshallow as last resort
         log.info("Deepening insufficient, performing full unshallow...")
         if not self._unshallow_repository():
             log.error(
@@ -3244,7 +3192,6 @@ class Orchestrator:
             "clone. Attempting graduated deepening to recover..."
         )
 
-        # Step 1: Try deepening first (cheaper than full unshallow)
         if self._deepen_repository(depth=100):
             log.debug("Retrying merge --squash after deepening...")
             # Reset the failed merge state before retrying
@@ -3277,7 +3224,6 @@ class Orchestrator:
                 log.info("Merge --squash succeeded after deepening repository")
                 return
 
-        # Step 2: Full unshallow as last resort
         log.info(
             "Deepening insufficient, performing full unshallow for merge..."
         )
@@ -3348,7 +3294,6 @@ class Orchestrator:
                         walk_exc,
                     )
 
-                # Remove the directory tree
                 shutil.rmtree(self._ssh_temp_dir)
                 log.debug(
                     "Securely cleaned up temporary SSH directory: %s",
@@ -3529,12 +3474,10 @@ class Orchestrator:
                 author=author, no_edit=True, signoff=True, cwd=self.workspace
             )
 
-            # Get current commit message
             cur_msg = run_cmd(
                 ["git", "show", "-s", "--pretty=format:%B", "HEAD"],
                 cwd=self.workspace,
             ).stdout
-            # Clean ellipses from commit message
             cur_msg = _clean_ellipses_from_message(cur_msg)
 
             # Determine Change-ID to use (reuse if provided)
@@ -3542,7 +3485,6 @@ class Orchestrator:
             if reuse_change_ids and idx < len(reuse_change_ids):
                 desired_change_id = reuse_change_ids[idx]
 
-            # Build topic for metadata
             if "/" in gh.repository:
                 repo_name = gh.repository.split("/")[-1]
             else:
@@ -3576,14 +3518,12 @@ class Orchestrator:
                     author=author,
                     cwd=self.workspace,
                 )
-            # Extract newly added Change-Id from last commit trailers
             trailers = git_last_commit_trailers(
                 keys=["Change-Id"], cwd=self.workspace
             )
             for cid in trailers.get("Change-Id", []):
                 if cid:
                     change_ids.append(cid)
-            # Return to base branch for next iteration context
             run_cmd(["git", "checkout", branch], cwd=self.workspace)
         # Deduplicate while preserving order
         seen = set()
@@ -3629,7 +3569,6 @@ class Orchestrator:
             ["git", "rev-parse", "HEAD"], cwd=self.workspace
         ).stdout.strip()
 
-        # Create temp branch from base and merge-squash PR head
         tmp_branch = f"g2g_tmp_{gh.pr_number or 'pr'!s}_{os.getpid()}"
         os.environ["G2G_TMP_BRANCH"] = tmp_branch
 
@@ -3716,7 +3655,6 @@ class Orchestrator:
                 merge_exc, base_sha, head_sha
             )
 
-            # Log error at debug level - user-friendly message comes later
             log.debug("Git merge --squash failed: %s", error_details)
             if recovery_msg:
                 log.debug("Suggested recovery: %s", recovery_msg)
@@ -3803,7 +3741,6 @@ class Orchestrator:
             # Apply conventional commit normalization if enabled
             if inputs.normalise_commit and gh.pr_number:
                 try:
-                    # Get PR author for normalization context
                     client = build_client()
                     repo = get_repo_from_env(client)
                     pr_obj = get_pull(repo, int(gh.pr_number))
@@ -3837,7 +3774,6 @@ class Orchestrator:
                     body_start += 1
                 if body_start < len(message_lines):
                     out.append("")
-                    # Clean up ellipses from body lines
                     body_content = "\n".join(message_lines[body_start:])
                     cleaned_body_content = _clean_ellipses_from_message(
                         body_content
@@ -3894,7 +3830,6 @@ class Orchestrator:
                 msg += "\n\n" + "\n".join(signed_off)
             return msg
 
-        # Build message parts
         raw_lines = _collect_log_lines()
         message_lines, signed_off, _existing_cids = _parse_message_parts(
             raw_lines
@@ -3902,13 +3837,10 @@ class Orchestrator:
         clean_lines = _build_clean_message_lines(message_lines)
         pr_str = str(gh.pr_number or "").strip()
         reuse_cid = _maybe_reuse_change_id(pr_str)
-        # Phase 3: if external reuse list provided, override with first
-        # Change-Id
         if reuse_change_ids:
             cand = reuse_change_ids[0]
             if cand:
                 reuse_cid = cand
-        # Build base message with Signed-off-by
         base_msg = _compose_base_message(clean_lines, signed_off)
 
         # Use centralized function to build complete message with all trailers
@@ -4023,7 +3955,6 @@ class Orchestrator:
         if title:
             # Remove markdown links like [text](url) and keep just the text
             title = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title)
-            # Remove any trailing ellipsis or truncation indicators
             title = re.sub(r"\s*[.]{3,}.*$", "", title)
             # Ensure title doesn't accidentally contain body content
             # Split on common separators and take only the first meaningful part
@@ -4031,7 +3962,6 @@ class Orchestrator:
                 if separator in title:
                     title = title.split(separator)[0].strip()
                     break
-            # Remove any remaining markdown or formatting artifacts
             title = re.sub(r"[*_`]", "", title)
             title = title.strip()
 
@@ -4041,7 +3971,6 @@ class Orchestrator:
                     title, author_login, self.workspace
                 )
 
-        # Get current commit message with all trailers
         current_body = git_show("HEAD", fmt="%B", cwd=self.workspace)
 
         # Split into message body and trailer block
@@ -4070,12 +3999,10 @@ class Orchestrator:
                 # Found non-trailer after trailers, stop
                 break
 
-        # Extract existing trailers
         existing_trailers = []
         if found_trailer_block:
             existing_trailers = lines[trailer_start_idx:]
 
-        # Build new message: title + body + preserved trailers
         new_message_parts = []
         if title:
             new_message_parts.append(title)
@@ -4094,7 +4021,6 @@ class Orchestrator:
 
         commit_message = "\n".join(new_message_parts).strip()
 
-        # Get current author
         author = run_cmd(
             ["git", "show", "-s", "--pretty=format:%an <%ae>", "HEAD"],
             cwd=self.workspace,
@@ -4234,7 +4160,6 @@ class Orchestrator:
             )
             log.debug("Working directory: %s", self.workspace)
 
-            # Execute the git review command
             run_cmd(args, cwd=self.workspace, env=env)
             log.debug("Successfully pushed changes to Gerrit")
         except CommandError as exc:
@@ -4368,7 +4293,6 @@ class Orchestrator:
                 f"{error_details}"
             )
             raise OrchestratorError(msg) from exc
-        # Cleanup temporary branch used during preparation
         else:
             # Successful push: emit mapping comment (Phase 2)
             try:
@@ -4388,7 +4312,6 @@ class Orchestrator:
                     "Failed to emit Change-Id map comment (success path): %s",
                     exc_emit,
                 )
-        # Cleanup temporary branch used during preparation
         tmp_branch = (os.getenv("G2G_TMP_BRANCH", "") or "").strip()
         if tmp_branch:
             # Switch back to the target branch, then delete the temp branch
@@ -4478,7 +4401,6 @@ class Orchestrator:
             return
 
         try:
-            # Get current organization for config lookup
             org = os.getenv("ORGANIZATION") or os.getenv(
                 "GITHUB_REPOSITORY_OWNER"
             )
@@ -4570,7 +4492,6 @@ class Orchestrator:
             return
 
         try:
-            # Get config path
             config_path = os.getenv("G2G_CONFIG_PATH", "").strip()
             if not config_path:
                 config_path = "~/.config/github2gerrit/configuration.txt"
@@ -4803,7 +4724,6 @@ class Orchestrator:
         # matching
         normalized_output = " ".join(combined_lower.split())
 
-        # Check for SSH host key verification failures first
         if (
             "host key verification failed" in combined_lower
             or "no ed25519 host key is known" in combined_lower
@@ -4868,7 +4788,6 @@ class Orchestrator:
                 "SSH public key authentication failed. The SSH key may be "
                 "invalid, not authorized for this user, or the wrong key type."
             )
-        # Check for general SSH permission issues
         elif "permission denied" in combined_lower:
             return "SSH permission denied - check SSH key and user permissions"
         elif "could not read from remote repository" in combined_lower:
@@ -4876,7 +4795,6 @@ class Orchestrator:
                 "Could not read from remote repository - check SSH "
                 "authentication and repository access permissions"
             )
-        # Check for Gerrit-specific issues
         elif "missing issue-id" in combined_lower:
             return "Missing Issue-ID in commit message."
         elif "commit not associated to any issue" in combined_lower:
@@ -4901,7 +4819,6 @@ class Orchestrator:
             lines = combined_output.split("\n")
             for line in lines:
                 if "! [remote rejected]" in line:
-                    # Extract the reason in parentheses
                     if "(" in line and ")" in line:
                         reason = line[line.find("(") + 1 : line.find(")")]
                         return f"Gerrit rejected the push: {reason}"
@@ -4947,9 +4864,7 @@ class Orchestrator:
             # include current revision
             query = f"limit:1 is:open project:{repo.project_gerrit} {cid}"
             path = f"/changes/?q={query}&o=CURRENT_REVISION&n=1"
-            # Build single API base URL via centralized discovery
             api_base_url = url_builder.api_url()
-            # Build Gerrit REST client with retry/timeout
             from .gerrit_rest import build_client_for_host
 
             client = build_client_for_host(
@@ -5017,7 +4932,6 @@ class Orchestrator:
 
         if use_ssh:
             repo_url = repo_ssh_url
-            # Set up SSH environment for private repos
             env = {
                 "GIT_SSH_COMMAND": build_git_ssh_command(),
                 **build_non_interactive_ssh_env(),
@@ -5032,7 +4946,6 @@ class Orchestrator:
             ["git", "remote", "add", "origin", repo_url], cwd=self.workspace
         )
 
-        # Fetch base branch and PR head with CLI's fallback logic
         fetch_success = False
 
         if base_ref:
@@ -5108,11 +5021,9 @@ class Orchestrator:
         try:
             parsed = urllib.parse.urlparse(server_url)
 
-            # Validate scheme
             if parsed.scheme not in ("http", "https"):
                 raise OrchestratorError(f"Invalid URL scheme: {parsed.scheme}")  # noqa: TRY003, TRY301
 
-            # Validate hostname exists
             hostname = parsed.hostname
             if not hostname:
                 raise OrchestratorError("Invalid URL: missing hostname")  # noqa: TRY003, TRY301
@@ -5182,7 +5093,6 @@ class Orchestrator:
                 msg = f"No IP addresses found for hostname: {hostname}"
                 raise OrchestratorError(msg)
 
-            # Extract and validate all unique IP addresses
             ip_addresses = set()
             for addr_info in addr_infos:
                 ip_str = addr_info[4][
@@ -5288,7 +5198,6 @@ class Orchestrator:
         repo_full = gh.repository.strip() if gh.repository else ""
         pr_num_str = str(gh.pr_number) if gh.pr_number else "0"
 
-        # Get GitHub token
         token = os.getenv("GITHUB_TOKEN", "").strip()
         if not token:
             msg = "No GITHUB_TOKEN available for API fallback"
@@ -5297,7 +5206,6 @@ class Orchestrator:
         # Determine API base URL with validation to prevent SSRF
         server_url = gh.server_url or "https://github.com"
         api_base = self._validate_and_get_api_base_url(server_url)
-        # Get PR details to find head SHA
         pr_api_url = f"{api_base}/repos/{repo_full}/pulls/{pr_num_str}"
         headers = {
             "Authorization": f"token {token}",
@@ -5329,7 +5237,6 @@ class Orchestrator:
         if not (workspace / ".git").exists():
             run_cmd(["git", "init"], cwd=workspace)
 
-        # Extract archive
         archive_path = workspace / "archive.zip"
         archive_path.write_bytes(archive_data)
 
@@ -5359,11 +5266,9 @@ class Orchestrator:
                         target.unlink()
                 shutil.move(str(item), str(target))
 
-        # Clean up
         source_dir.rmdir()
         archive_path.unlink()
 
-        # Create expected branch
         run_cmd(["git", "checkout", "-B", "g2g_pr_head"], cwd=workspace)
 
         log.info("Successfully set up workspace using GitHub API archive")
@@ -5378,7 +5283,6 @@ class Orchestrator:
 
         # Download commit-msg hook using centralized curl framework
         try:
-            # Create centralized URL builder for hook URLs
             url_builder = create_gerrit_url_builder(gerrit.host)
             hook_url = url_builder.hook_url("commit-msg")
 
@@ -5417,7 +5321,6 @@ class Orchestrator:
             if size < 128 or size > 65536:
                 _raise_orch(_MSG_HOOK_SIZE_BOUNDS)
 
-            # Validate content characteristics
             text_head = ""
             try:
                 with open(hook_path, "rb") as fh:
@@ -5465,7 +5368,6 @@ class Orchestrator:
             log.debug(
                 "Found existing Change-Id(s) in footer: %s", existing_change_ids
             )
-            # Clean up any duplicate Change-IDs in the message body
             self._clean_change_ids_from_body(author)
             return [c for c in existing_change_ids if c]
 
@@ -5550,7 +5452,6 @@ class Orchestrator:
         trailers."""
         lines = message.splitlines()
 
-        # Parse proper trailers using the fixed trailer parser
         trailers = _parse_trailers(message)
         change_id_trailers = trailers.get("Change-Id", [])
         signed_off_trailers = trailers.get("Signed-off-by", [])
@@ -5592,7 +5493,6 @@ class Orchestrator:
         body_lines = []
         for i in range(trailer_start):
             line = lines[i]
-            # Remove any Change-Id references from body lines
             if "Change-Id:" in line:
                 # If line starts with Change-Id:, skip it entirely
                 if line.strip().startswith("Change-Id:"):
@@ -5609,7 +5509,6 @@ class Orchestrator:
                     # Pattern to match "Change-Id: <value>" where value can
                     # contain word chars, hyphens, etc.
                     line = re.sub(r"Change-Id:\s*[A-Za-z0-9._-]+\b", "", line)
-                    # Clean up extra whitespace
                     line = re.sub(r"\s+", " ", line).strip()
                     if line != original_line:
                         log.debug(
@@ -5620,7 +5519,6 @@ class Orchestrator:
                         )
             body_lines.append(line)
 
-        # Remove trailing empty lines from body
         while body_lines and not body_lines[-1].strip():
             body_lines.pop()
 
@@ -5746,7 +5644,6 @@ class Orchestrator:
             if not csha:
                 log.debug("Empty commit SHA, skipping")
                 continue
-            # Build SSH command based on available authentication method
             ssh_cmd: list[str] = []
             try:
                 log.debug("Executing SSH command for commit %s", csha)
@@ -6088,7 +5985,6 @@ class Orchestrator:
             msg = "GitHub API validation failed"
             raise OrchestratorError(msg) from exc
 
-        # Log effective targets
         log.debug(
             "Dry-run targets: Gerrit project=%s branch=%s topic_prefix=GH-%s",
             repo.project_gerrit,
@@ -6139,10 +6035,6 @@ class Orchestrator:
             url_builder = create_gerrit_url_builder(host, base_path)
             api_url = url_builder.api_url()
             log.warning("Gerrit REST probe failed for %s: %s", api_url, exc)
-
-    # ---------------
-    # Helpers
-    # ---------------
 
     def _resolve_target_branch(self) -> str:
         # Preference order:
@@ -6240,7 +6132,6 @@ class Orchestrator:
             return
 
         try:
-            # Get files changed in the GitHub PR
             from .github_api import build_client
             from .github_api import get_pull
             from .github_api import get_repo_from_env
@@ -6249,7 +6140,6 @@ class Orchestrator:
             repo = get_repo_from_env(client)
             pr_obj = get_pull(repo, int(gh.pr_number))
 
-            # Get list of files changed in the PR
             github_files = set()
             for file in pr_obj.get_files():  # type: ignore[attr-defined]
                 github_files.add(file.filename)
@@ -6260,10 +6150,8 @@ class Orchestrator:
                 sorted(github_files),
             )
 
-            # Check files in each commit SHA that was pushed to Gerrit
             for commit_sha in result.commit_shas:
                 try:
-                    # Get files changed in the Gerrit commit
                     from .gitutils import run_cmd
 
                     files_output = run_cmd(
@@ -6290,7 +6178,6 @@ class Orchestrator:
                         sorted(gerrit_files),
                     )
 
-                    # Check for unexpected files
                     unexpected_files = gerrit_files - github_files
                     if unexpected_files:
                         # Filter out known safe files that might legitimately
@@ -6518,6 +6405,10 @@ class Orchestrator:
             if head_result.returncode == 0:
                 log.error("Current HEAD: %s", head_result.stdout.strip())
 
+        # log.exception records the caught error and traceback; this
+        # diagnostic helper must never mask the original merge failure
+        # being analyzed.
+        # aislop-ignore-next-line silent-recovery
         except Exception:
             log.exception("Failed to gather debug context")
 
@@ -6552,7 +6443,6 @@ class Orchestrator:
         except Exception as e:
             log.debug("Failed to check existing git identity: %s", e)
 
-        # Configure git identity using Gerrit credentials
         user_name = inputs.gerrit_ssh_user_g2g or "github2gerrit-bot"
         user_email = (
             inputs.gerrit_ssh_user_g2g_email or "github2gerrit@example.com"
@@ -6583,8 +6473,3 @@ class Orchestrator:
                 log.exception("Failed to configure git user identity")
                 msg = "Cannot configure git user identity"
                 raise OrchestratorError(msg) from global_e
-
-
-# ---------------------
-# Utility functions
-# ---------------------

--- a/src/github2gerrit/duplicate_detection.py
+++ b/src/github2gerrit/duplicate_detection.py
@@ -70,7 +70,6 @@ class ChangeFingerprint:
 
     def _normalize_title(self, title: str) -> str:
         """Normalize PR title for comparison."""
-        # Remove common prefixes/suffixes
         normalized = title.strip()
 
         # Remove conventional commit prefixes like "feat:", "fix:", etc.
@@ -82,7 +81,6 @@ class ChangeFingerprint:
             flags=re.IGNORECASE,
         )
 
-        # Remove markdown formatting
         normalized = re.sub(r"[*_`]", "", normalized)
 
         # Remove version number variations for dependency updates
@@ -92,7 +90,6 @@ class ChangeFingerprint:
         normalized = re.sub(r"\b\d+(\.\d+)+(-\w+)?\b", "x.y.z", normalized)
         normalized = re.sub(r"\b\d+\.\d+\b", "x.y.z", normalized)
 
-        # Remove specific commit hashes
         normalized = re.sub(r"\b[a-f0-9]{7,40}\b", "commit_hash", normalized)
 
         # Normalize whitespace
@@ -130,7 +127,6 @@ class ChangeFingerprint:
                 if overlap_ratio > 0:
                     return self._titles_similar(other, 0.6)
 
-        # Check title similarity even without file changes
         return self._titles_similar(other, similarity_threshold)
 
     def _titles_similar(
@@ -359,7 +355,6 @@ class DuplicateDetector:
             normalized_pr_subject,
         )
 
-        # Build Gerrit REST URL using centralized URL builder
         url_builder = create_gerrit_url_builder(gerrit_host)
 
         # Track which base path actually works for constructing display URLs
@@ -689,7 +684,6 @@ class DuplicateDetector:
                     if isinstance(num, int):
                         all_nums.append(num)
 
-                    # Log special handling
                     if (
                         is_perfect_dependency_match
                         and agg < config.similarity_threshold
@@ -711,7 +705,6 @@ class DuplicateDetector:
             if hits:
                 hits_sorted = sorted(hits, key=lambda t: t[0], reverse=True)
 
-                # Log each matching change individually and display on console
                 for s, u, _ in hits_sorted:
                     if u:
                         log.debug("Score: %.2f  URL: %s", s, u)
@@ -809,11 +802,9 @@ def check_for_duplicates(
             "GitHub repository: %s", getattr(repo, "full_name", "unknown")
         )
 
-        # Get the target PR
         target_pr = repo.get_pull(gh.pr_number)
         log.debug("Retrieved PR #%s: %s", target_pr.number, target_pr.title)
 
-        # Create detector and check
         duplicate_types = os.getenv("DUPLICATE_TYPES", "open")
         log.debug(
             "Checking for duplicates in Gerrit changes with states: %s",

--- a/src/github2gerrit/error_codes.py
+++ b/src/github2gerrit/error_codes.py
@@ -311,7 +311,6 @@ def _is_github_exception_with_permission_error(exception: Exception) -> bool:
         status = _get_exc_attr(exception, "status")
         if status in (401, 403, 404):
             return True
-        # Check for data attribute with status
         data = _get_exc_attr(exception, "data")
         if isinstance(data, dict) and data.get("status") in (401, 403, 404):
             return True
@@ -327,7 +326,6 @@ def _has_permission_related_http_status(exception: Exception) -> bool:
             if isinstance(status, int) and status in (401, 403, 404):
                 return True
 
-    # Check for requests.HTTPError or similar
     response = _get_exc_attr(exception, "response")
     if response is not None:
         status = getattr(response, "status_code", None)
@@ -348,12 +346,10 @@ def _matches_github_permission_patterns(exception: Exception) -> bool:
         "requires authentication",
     ]
 
-    # Check high-confidence patterns first
     for pattern in github_api_patterns:
         if pattern in error_str:
             return True
 
-    # Check for HTTP status indicators in context
     status_indicators = ["401", "403", "forbidden", "unauthorized"]
     context_indicators = ["api", "http", "github", "request", "response"]
     if any(indicator in error_str for indicator in status_indicators) and any(
@@ -394,7 +390,6 @@ def is_gerrit_connection_error(exception: Exception) -> bool:
     """
     error_str = str(exception).lower()
 
-    # Define regex patterns for Gerrit connection errors
     gerrit_patterns = [
         r"connection refused",
         r"connection timed out",
@@ -425,7 +420,6 @@ def is_network_error(exception: Exception) -> bool:
     """
     error_str = str(exception).lower()
 
-    # Define regex patterns for network errors
     network_patterns = [
         r"network is unreachable",
         r"name resolution failed",
@@ -527,7 +521,6 @@ def convert_orchestrator_error(
         error_msg, original_exception
     )
 
-    # Create user-friendly message based on exit code
     if exit_code == ExitCode.CONFIGURATION_ERROR:
         user_message = (
             "❌ Configuration validation failed; check required parameters"

--- a/src/github2gerrit/external_api.py
+++ b/src/github2gerrit/external_api.py
@@ -170,7 +170,6 @@ def _is_transient_error(exc: BaseException, api_type: ApiType) -> bool:
 
     # GitHub API specific errors (if PyGithub is available)
     if api_type == ApiType.GITHUB:
-        # Import GitHub exception types to check isinstance
         try:
             from .github_api import GithubExceptionType
             from .github_api import RateLimitExceededExceptionType
@@ -178,7 +177,6 @@ def _is_transient_error(exc: BaseException, api_type: ApiType) -> bool:
             GithubExceptionType = type(None)  # type: ignore[misc,assignment]
             RateLimitExceededExceptionType = type(None)  # type: ignore[misc,assignment]
 
-        # Check by class name or isinstance for mock/test exceptions
         exc_name = exc.__class__.__name__
         if exc_name in (
             "RateLimitExceededException",
@@ -191,7 +189,6 @@ def _is_transient_error(exc: BaseException, api_type: ApiType) -> bool:
             status = getattr(exc, "status", None)
             if isinstance(status, int) and 500 <= status <= 599:
                 return True
-            # Check for rate limit in error data
             data = getattr(exc, "data", "")
             if isinstance(data, str | bytes):
                 try:
@@ -212,7 +209,6 @@ def _is_transient_error(exc: BaseException, api_type: ApiType) -> bool:
 
     # Gerrit REST specific errors - check for wrapped HTTP errors
     if api_type == ApiType.GERRIT_REST:
-        # Handle GerritRestError that wraps HTTP errors
         if "HTTP 5" in str(exc) or "HTTP 429" in str(exc):
             return True
         # Also check for original HTTP errors that caused the GerritRestError
@@ -509,7 +505,6 @@ def curl_download(
         if silent:
             cmd.append("-sS")
 
-        # Write HTTP status code to stdout
         cmd.extend(["-w", "%{http_code}"])
 
         # Set timeout
@@ -546,7 +541,6 @@ def curl_download(
                 )
             ) from exc
 
-        # Initialize variables
         result = None
         http_status = "unknown"
 
@@ -560,7 +554,6 @@ def curl_download(
                 check=False,
             )
 
-            # Extract HTTP status code from stdout
             http_status = result.stdout.strip() if result.stdout else "unknown"
 
             if result.returncode != 0:

--- a/src/github2gerrit/gerrit_pr_closer.py
+++ b/src/github2gerrit/gerrit_pr_closer.py
@@ -138,14 +138,12 @@ def check_gerrit_change_status(
     host, change_number = parsed
 
     try:
-        # Build Gerrit REST client for the host
         client = build_client_for_host(host)
 
         # Query change details
         # Gerrit REST API endpoint: GET /changes/{change-id}
         change_data = client.get(f"/changes/{change_number}")
 
-        # Extract status from response
         status = change_data.get("status", "UNKNOWN")
         log.debug("Gerrit change %s status: %s", change_number, status)
     except GerritRestError as exc:
@@ -163,7 +161,6 @@ def check_gerrit_change_status(
         )
         return "UNKNOWN"
     else:
-        # Validate status against allowed values for type safety
         allowed_statuses = ("MERGED", "ABANDONED", "NEW", "UNKNOWN")
         result: Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"] = (
             status if status in allowed_statuses else "UNKNOWN"
@@ -189,10 +186,8 @@ def extract_pr_url_from_commit(commit_sha: str) -> str | None:
         GitHub PR URL if found, None otherwise
     """
     try:
-        # Get the commit message
         commit_message = git_show(commit_sha, fmt="%B")
 
-        # Parse trailers
         trailers = parse_trailers(commit_message)
 
         # Look for GitHub-PR trailer
@@ -274,7 +269,6 @@ def extract_pr_url_from_gerrit_change(gerrit_change_url: str) -> str | None:
     host, change_number = parsed
 
     try:
-        # Build Gerrit REST client for the host
         client = build_client_for_host(host)
 
         # Query change details including commit message
@@ -287,7 +281,6 @@ def extract_pr_url_from_gerrit_change(gerrit_change_url: str) -> str | None:
             log.debug("No current revision found for change %s", change_number)
             return None
 
-        # Get commit message from the revision data
         revisions = change_data.get("revisions", {})
         revision_data = revisions.get(current_revision, {})
         commit_data = revision_data.get("commit", {})
@@ -297,7 +290,6 @@ def extract_pr_url_from_gerrit_change(gerrit_change_url: str) -> str | None:
             log.debug("No commit message found for change %s", change_number)
             return None
 
-        # Parse trailers to find GitHub-PR URL
         trailers = parse_trailers(commit_message)
         pr_urls = trailers.get(GITHUB_PR_TRAILER, [])
 
@@ -347,28 +339,23 @@ def extract_pr_info_for_display(
         Dictionary of PR information for display
     """
     try:
-        # Get PR title
         title = getattr(pr_obj, "title", "No title")
 
-        # Get PR author
         author = "Unknown"
         user = getattr(pr_obj, "user", None)
         if user:
             author = getattr(user, "login", "Unknown") or "Unknown"
 
-        # Get base branch
         base_branch = "unknown"
         base = getattr(pr_obj, "base", None)
         if base:
             base_branch = getattr(base, "ref", "unknown") or "unknown"
 
-        # Get SHA
         sha = "unknown"
         head = getattr(pr_obj, "head", None)
         if head:
             sha = getattr(head, "sha", "unknown") or "unknown"
 
-        # Build PR info dictionary
         pr_info = {
             "Repository": f"{owner}/{repo}",
             "PR Number": pr_number,
@@ -425,7 +412,6 @@ def close_pr_with_status(
     Returns:
         True if PR was closed (or would be closed in dry-run), False otherwise
     """
-    # Parse PR URL
     parsed = parse_pr_url(pr_url)
     if not parsed:
         log.info("Invalid GitHub PR URL format: %s - skipping", pr_url)
@@ -435,13 +421,11 @@ def close_pr_with_status(
     log.debug("Found GitHub PR: %s/%s#%d", owner, repo, pr_number)
 
     try:
-        # Build GitHub client and get repository
         client = build_client()
 
         # Get the specific repository (not from env, might be different)
         repo_obj = client.get_repo(f"{owner}/{repo}")
 
-        # Fetch the pull request
         try:
             pr_obj = get_pull(repo_obj, pr_number)
         except Exception as exc:
@@ -471,7 +455,6 @@ def close_pr_with_status(
             )
             return False
 
-        # Extract and display PR information
         pr_info = extract_pr_info_for_display(pr_obj, owner, repo, pr_number)
         display_pr_info(
             pr_info, context="Abandoned", progress_tracker=progress_tracker
@@ -521,7 +504,6 @@ def close_pr_with_status(
             close_pr(pr_obj, comment=comment)
             log.debug("SUCCESS: Closed GitHub PR #%d", pr_number)
 
-            # Extract Gerrit change number from URL
             gerrit_change_number = "unknown"
             if gerrit_change_url:
                 match = re.search(r"/c/[^/]+/\+/(\d+)", gerrit_change_url)
@@ -559,7 +541,6 @@ def close_pr_with_status(
         error_type = type(exc).__name__
         error_details = str(exc)
 
-        # Check for common error patterns
         if "401" in error_details or "403" in error_details:
             log.exception(
                 "Authentication/authorization error while closing PR #%d: "
@@ -580,7 +561,6 @@ def close_pr_with_status(
                 error_details,
             )
         else:
-            # Log with full traceback for unexpected errors
             log.exception(
                 "Unexpected error (%s) while closing PR #%d: %s",
                 error_type,
@@ -623,11 +603,14 @@ def close_github_pr_for_merged_gerrit_change(
     """
     log.info("Processing Gerrit change: %s", commit_sha[:8])
 
-    # Check Gerrit change status
     gerrit_status: Literal["MERGED", "ABANDONED", "NEW", "UNKNOWN"] = "UNKNOWN"
     if gerrit_change_url:
         gerrit_status = check_gerrit_change_status(gerrit_change_url)
 
+        # Branches vary in log level and nested close_merged_prs
+        # handling, so a dispatch table would obscure this status
+        # logging.
+        # aislop-ignore-next-line python-repetitive-dispatch
         if gerrit_status == "ABANDONED":
             if close_merged_prs:
                 log.info(
@@ -651,7 +634,6 @@ def close_github_pr_for_merged_gerrit_change(
         elif gerrit_status == "MERGED":
             log.debug("Gerrit change confirmed as MERGED")
 
-    # Extract PR URL from commit
     pr_url = extract_pr_url_from_commit(commit_sha)
     if not pr_url:
         log.info(
@@ -909,7 +891,6 @@ def cleanup_abandoned_prs_single(
     safe_console_print("⛔️ Checking for abandoned Gerrit changes")
     log.debug("Checking Gerrit change: %s", gerrit_change_url)
 
-    # Check Gerrit change status
     status = check_gerrit_change_status(gerrit_change_url)
 
     if status != "ABANDONED":
@@ -921,7 +902,6 @@ def cleanup_abandoned_prs_single(
 
     log.info("Gerrit change is ABANDONED, looking for GitHub PR to close")
 
-    # Extract PR URL from Gerrit change
     pr_url = extract_pr_url_from_gerrit_change(gerrit_change_url)
     if not pr_url:
         log.info(
@@ -979,11 +959,9 @@ def cleanup_abandoned_prs_bulk(
     )
 
     try:
-        # Build GitHub client and get repository
         client = build_client()
         repo_obj = client.get_repo(f"{owner}/{repo}")
 
-        # Get all open PRs
         open_prs = list(iter_open_pulls(repo_obj))
         if not open_prs:
             log.debug("No open pull requests found in %s/%s", owner, repo)
@@ -993,13 +971,11 @@ def cleanup_abandoned_prs_bulk(
 
         closed_count = 0
 
-        # Process each open PR
         for pr in open_prs:
             pr_number = pr.number
             log.debug("Checking PR #%d for Gerrit change status", pr_number)
 
             try:
-                # Get the PR's issue to access comments
                 issue = pr.as_issue()
                 comments = list(issue.get_comments())
 
@@ -1035,7 +1011,6 @@ def cleanup_abandoned_prs_bulk(
                         pr_number,
                     )
 
-                    # Build PR URL from PR object
                     pr_url = (
                         f"https://github.com/{owner}/{repo}/pull/{pr_number}"
                     )
@@ -1058,7 +1033,6 @@ def cleanup_abandoned_prs_bulk(
                     )
 
             except Exception as exc:
-                # Log but don't fail - continue processing other PRs
                 log.warning(
                     "Error processing PR #%d: %s - skipping",
                     pr_number,
@@ -1110,10 +1084,8 @@ def abandon_gerrit_change_for_closed_pr(
     )
 
     try:
-        # Build Gerrit REST client
         gerrit_client = build_client_for_host(gerrit_server)
 
-        # Build expected PR URL to search for in Gerrit changes
         pr_url = f"https://github.com/{repository}/pull/{pr_number}"
 
         # Query for open changes with this PR URL in the commit message
@@ -1149,7 +1121,6 @@ def abandon_gerrit_change_for_closed_pr(
                 if not commit_message:
                     continue
 
-                # Parse trailers to find GitHub-PR
                 trailers = parse_trailers(commit_message)
                 pr_urls = trailers.get(GITHUB_PR_TRAILER, [])
 
@@ -1187,13 +1158,11 @@ def abandon_gerrit_change_for_closed_pr(
             pr_number,
         )
 
-        # Get PR closure information from GitHub
         try:
             client = build_client()
             repo_obj = client.get_repo(repository)
             pr_obj = get_pull(repo_obj, pr_number)
 
-            # Get closure comments
             closure_comments = []
             try:
                 issue = pr_obj.as_issue()
@@ -1221,7 +1190,6 @@ def abandon_gerrit_change_for_closed_pr(
             except Exception as exc:
                 log.debug("Error getting PR comments: %s", exc)
 
-            # Build abandon message
             abandon_message_lines = [
                 f"GitHub pull request #{pr_number} was closed",
                 "",
@@ -1386,7 +1354,6 @@ def cleanup_closed_github_prs(
     )
 
     try:
-        # Build Gerrit REST client
         from .gerrit_rest import build_client_for_host
 
         gerrit_client = build_client_for_host(gerrit_server)
@@ -1408,7 +1375,6 @@ def cleanup_closed_github_prs(
 
         abandoned_count = 0
 
-        # Process each open Gerrit change
         for change_data in changes_data:
             try:
                 change_number = change_data.get("_number", "")
@@ -1418,7 +1384,6 @@ def cleanup_closed_github_prs(
                     "Checking Gerrit change %s (%s)", change_number, subject
                 )
 
-                # Extract commit message to find GitHub PR URL
                 current_revision = change_data.get("current_revision", "")
                 if not current_revision:
                     log.debug(
@@ -1439,7 +1404,6 @@ def cleanup_closed_github_prs(
                     )
                     continue
 
-                # Extract GitHub PR URL from commit trailers
                 trailers = parse_trailers(commit_message)
                 pr_urls = trailers.get(GITHUB_PR_TRAILER, [])
 
@@ -1457,7 +1421,6 @@ def cleanup_closed_github_prs(
                     pr_url,
                 )
 
-                # Parse PR URL to get owner, repo, and PR number
                 parsed = parse_pr_url(pr_url)
                 if not parsed:
                     log.debug(
@@ -1469,7 +1432,6 @@ def cleanup_closed_github_prs(
 
                 owner, repo, pr_number = parsed
 
-                # Check GitHub PR status
                 try:
                     client = build_client()
                     repo_obj = client.get_repo(f"{owner}/{repo}")
@@ -1582,7 +1544,6 @@ def _build_gerrit_abandon_message(pr_obj: Any, pr_url: str) -> str:
     """
     pr_number = pr_obj.number
 
-    # Check for Dependabot supersession
     try:
         issue = pr_obj.as_issue()
         comments = list(issue.get_comments())
@@ -1590,7 +1551,6 @@ def _build_gerrit_abandon_message(pr_obj: Any, pr_url: str) -> str:
         for comment in comments:
             body = getattr(comment, "body", "") or ""
             if "Superseded by" in body:
-                # Extract superseding PR number
                 match = re.search(r"Superseded by #(\d+)", body)
                 if match:
                     new_pr_number = match.group(1)
@@ -1867,7 +1827,6 @@ def abandon_superseded_dependency_changes(
             if not candidate_pkg or candidate_pkg != current_pkg:
                 continue
 
-            # Parse change number for URL construction
             try:
                 candidate_num = int(change.number)
             except (TypeError, ValueError):

--- a/src/github2gerrit/gerrit_query.py
+++ b/src/github2gerrit/gerrit_query.py
@@ -54,18 +54,15 @@ class GerritChange:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "GerritChange":
         """Create GerritChange from Gerrit REST API response."""
-        # Extract files from current revision
-        files = []
-        current_revision = data.get("current_revision", "")
-        if current_revision and "revisions" in data:
-            revision_data = data["revisions"].get(current_revision, {})
-            files = list(revision_data.get("files", {}).keys())
-
-        # Extract commit message
+        files: list[str] = []
         commit_message = ""
-        if current_revision and "revisions" in data:
-            revision_data = data["revisions"].get(current_revision, {})
-            commit_message = revision_data.get("commit", {}).get("message", "")
+        current_revision = data.get("current_revision", "")
+        if current_revision:
+            revisions = data.get("revisions") or {}
+            revision_data = revisions.get(current_revision) or {}
+            files = list((revision_data.get("files") or {}).keys())
+            commit_info = revision_data.get("commit") or {}
+            commit_message = commit_info.get("message", "")
 
         return cls(
             change_id=data.get("change_id", ""),
@@ -101,7 +98,6 @@ def query_changes_by_topic(
     if statuses is None:
         statuses = ["NEW"]
 
-    # Build query string
     status_query = " OR ".join(f"status:{status}" for status in statuses)
     query = f'topic:"{_gerrit_quote(topic)}" AND ({status_query})'
 
@@ -407,7 +403,6 @@ def extract_pr_metadata_from_commit_message(
             trailer_start = i + 1
             break
 
-    # Parse trailer lines
     for raw_line in lines[trailer_start:]:
         line = raw_line.strip()
         if ":" in line:
@@ -446,7 +441,6 @@ def validate_pr_metadata_match(
             change.commit_message
         )
 
-        # Check GitHub-PR URL match
         pr_url = metadata.get("GitHub-PR", "")
         if pr_url and pr_url != expected_pr_url:
             log.debug(
@@ -457,7 +451,6 @@ def validate_pr_metadata_match(
             )
             continue
 
-        # Check GitHub-Hash match
         github_hash = metadata.get("GitHub-Hash", "")
         if github_hash and github_hash != expected_github_hash:
             log.debug(

--- a/src/github2gerrit/github_api.py
+++ b/src/github2gerrit/github_api.py
@@ -244,7 +244,6 @@ def get_pull(repo: GhRepository, number: int) -> GhPullRequest:
         pr = repo.get_pull(number)
     except Exception as exc:
         if is_github_api_permission_error(exc):
-            # Extract repository name for better error message
             repo_name = getattr(repo, "full_name", "unknown")
             raise GitHub2GerritError(
                 ExitCode.GITHUB_API_ERROR,

--- a/src/github2gerrit/gitreview.py
+++ b/src/github2gerrit/gitreview.py
@@ -42,30 +42,12 @@ from typing import Final
 
 log = logging.getLogger(__name__)
 
-# ───────────────────────────────────────────────────────────────────────
-# Constants
-# ───────────────────────────────────────────────────────────────────────
-
 DEFAULT_GERRIT_PORT: int = 29418
 """Default Gerrit SSH port when the ``port=`` line is absent."""
-
-# ───────────────────────────────────────────────────────────────────────
-# Precompiled regex patterns for INI-style .gitreview files
-#
-# These patterns:
-#   • are multiline (``(?m)``)
-#   • are case-insensitive on the key name (``(?i)``)
-#   • tolerate optional horizontal whitespace around ``=``
-#   • strip trailing whitespace / ``\r`` so Windows line endings are handled
-# ───────────────────────────────────────────────────────────────────────
 
 _HOST_RE = re.compile(r"(?mi)^host[ \t]*=[ \t]*(.+?)[ \t\r]*$")
 _PORT_RE = re.compile(r"(?mi)^port[ \t]*=[ \t]*(\d+)[ \t\r]*$")
 _PROJECT_RE = re.compile(r"(?mi)^project[ \t]*=[ \t]*(.+?)[ \t\r]*$")
-
-# ───────────────────────────────────────────────────────────────────────
-# Data model
-# ───────────────────────────────────────────────────────────────────────
 
 
 @dataclass(frozen=True)
@@ -121,10 +103,6 @@ the addition of the optional ``base_path`` field (default ``None``).
 """
 
 
-# ───────────────────────────────────────────────────────────────────────
-# Well-known Gerrit base paths
-# ───────────────────────────────────────────────────────────────────────
-
 _KNOWN_BASE_PATHS: dict[str, str] = {
     "gerrit.linuxfoundation.org": "infra",
 }
@@ -149,11 +127,6 @@ def derive_base_path(host: str) -> str | None:
         not in the known-hosts table.
     """
     return _KNOWN_BASE_PATHS.get(host.lower().strip())
-
-
-# ───────────────────────────────────────────────────────────────────────
-# Pure parser
-# ───────────────────────────────────────────────────────────────────────
 
 
 def parse_gitreview(text: str) -> GitReviewInfo | None:
@@ -212,11 +185,6 @@ def parse_gitreview(text: str) -> GitReviewInfo | None:
     return info
 
 
-# ───────────────────────────────────────────────────────────────────────
-# Local file reader
-# ───────────────────────────────────────────────────────────────────────
-
-
 def read_local_gitreview(path: Path | None = None) -> GitReviewInfo | None:
     """Read and parse a local ``.gitreview`` file.
 
@@ -245,11 +213,6 @@ def read_local_gitreview(path: Path | None = None) -> GitReviewInfo | None:
     else:
         log.debug("Local .gitreview at %s missing required fields", target)
     return info
-
-
-# ───────────────────────────────────────────────────────────────────────
-# Remote fetch: raw.githubusercontent.com  (stdlib only)
-# ───────────────────────────────────────────────────────────────────────
 
 
 def _build_branch_list(
@@ -374,11 +337,6 @@ def fetch_gitreview_raw(
     return None
 
 
-# ───────────────────────────────────────────────────────────────────────
-# Remote fetch: GitHub API  (requires PyGithub — lazy import)
-# ───────────────────────────────────────────────────────────────────────
-
-
 def fetch_gitreview_github_api(
     repo_obj: Any,
     *,
@@ -418,11 +376,6 @@ def fetch_gitreview_github_api(
     elif info is None:
         log.debug("GitHub API: .gitreview not available or missing fields")
     return info
-
-
-# ───────────────────────────────────────────────────────────────────────
-# Unified fetch: tries all strategies in priority order
-# ───────────────────────────────────────────────────────────────────────
 
 
 def fetch_gitreview(
@@ -501,11 +454,6 @@ def fetch_gitreview(
     return None
 
 
-# ───────────────────────────────────────────────────────────────────────
-# Convenience: host-only accessor (replaces config._read_gitreview_host)
-# ───────────────────────────────────────────────────────────────────────
-
-
 def read_gitreview_host(
     repository: str | None = None,
     *,
@@ -534,10 +482,6 @@ def read_gitreview_host(
     )
     return info.host if info else None
 
-
-# ───────────────────────────────────────────────────────────────────────
-# Factory: build GitReviewInfo from explicit parameters
-# ───────────────────────────────────────────────────────────────────────
 
 _BASE_PATH_UNSET: Final[object] = object()
 """Sentinel value for :func:`make_gitreview_info` to distinguish

--- a/src/github2gerrit/gitutils.py
+++ b/src/github2gerrit/gitutils.py
@@ -362,11 +362,6 @@ def run_cmd_with_retries(
         return res
 
 
-# ----------------------------
-# Git helper functions
-# ----------------------------
-
-
 def git(
     args: Sequence[str],
     *,

--- a/src/github2gerrit/mapping_comment.py
+++ b/src/github2gerrit/mapping_comment.py
@@ -40,7 +40,6 @@ class ChangeIdMapping:
         if not self.change_ids:
             raise ValueError(_MSG_NO_CHANGE_IDS)
 
-        # Validate Change-Id format
         for cid in self.change_ids:
             if not cid.startswith("I") or len(cid) < 8:
                 raise ValueError(_MSG_INVALID_CHANGE_ID_FORMAT)
@@ -120,7 +119,6 @@ def parse_mapping_comments(comment_bodies: list[str]) -> ChangeIdMapping | None:
             continue
 
         try:
-            # Extract the mapping block
             start_idx = body.find(start_marker)
             end_idx = body.find(end_marker)
 

--- a/src/github2gerrit/netrc.py
+++ b/src/github2gerrit/netrc.py
@@ -36,6 +36,14 @@ _TOKEN_PASSWORD = "password"  # noqa: S105
 _TOKEN_DEFAULT = "default"  # noqa: S105
 _TOKEN_MACDEF = "macdef"  # noqa: S105
 
+_QUOTED_STRING_ESCAPES = {
+    '"': '"',
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "\\": "\\",
+}
+
 
 def _normalize_host_for_netrc_lookup(host: str) -> str:
     """Normalize a host string for .netrc lookup.
@@ -61,10 +69,8 @@ def _normalize_host_for_netrc_lookup(host: str) -> str:
     # Remove scheme (http://, https://, etc.)
     if "://" in normalized:
         normalized = normalized.split("://", 1)[1]
-    # Remove path components
     if "/" in normalized:
         normalized = normalized.split("/", 1)[0]
-    # Remove port number
     if ":" in normalized:
         normalized = normalized.rsplit(":", 1)[0]
     return normalized
@@ -174,27 +180,16 @@ class NetrcParser:
         Returns:
             Unescaped string content without quotes.
         """
-        # Remove surrounding quotes
         inner = s[1:-1]
-        # Process escape sequences
         result: list[str] = []
         i = 0
         while i < len(inner):
             if inner[i] == "\\" and i + 1 < len(inner):
                 next_char = inner[i + 1]
-                if next_char == '"':
-                    result.append('"')
-                elif next_char == "n":
-                    result.append("\n")
-                elif next_char == "r":
-                    result.append("\r")
-                elif next_char == "t":
-                    result.append("\t")
-                elif next_char == "\\":
-                    result.append("\\")
-                else:
-                    # Unknown escape, keep as-is
-                    result.append(inner[i : i + 2])
+                # Unknown escapes are kept as-is
+                result.append(
+                    _QUOTED_STRING_ESCAPES.get(next_char, inner[i : i + 2])
+                )
                 i += 2
             else:
                 result.append(inner[i])
@@ -228,7 +223,6 @@ class NetrcParser:
             List of tokens, including "\n" tokens for line boundaries.
         """
         tokens: list[str] = []
-        # Process line by line to preserve newline information
         lines: list[str] = []
         for raw_line in content.splitlines():
             # Strip leading whitespace to check for comment
@@ -237,7 +231,6 @@ class NetrcParser:
                 # Preserve blank line marker for macdef parsing
                 lines.append("")
                 continue
-            # Handle inline comments
             processed_line = self._strip_inline_comment(raw_line)
             lines.append(processed_line)
 
@@ -252,7 +245,6 @@ class NetrcParser:
             placeholder_idx += 1
             return placeholder
 
-        # Process each line, preserving newline tokens
         for line in lines:
             # Replace quoted strings with placeholders
             processed_line = self._QUOTED_STRING_PATTERN.sub(
@@ -269,7 +261,6 @@ class NetrcParser:
                         self._unescape_quoted_string(placeholders[raw_token])
                     )
                 elif "\x00QUOTED" in raw_token:
-                    # Handle case where placeholder is part of larger token
                     processed_token = raw_token
                     for placeholder, quoted in placeholders.items():
                         if placeholder in processed_token:

--- a/src/github2gerrit/orchestrator/reconciliation.py
+++ b/src/github2gerrit/orchestrator/reconciliation.py
@@ -55,11 +55,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
 def perform_reconciliation(
     inputs: Inputs,
     gh: GitHubContext,
@@ -217,11 +212,6 @@ def perform_reconciliation(
         plan, log_json=getattr(inputs, "log_reconcile_json", False)
     )
     return plan.change_ids
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
 
 
 def _query_and_validate_topic_changes(
@@ -400,11 +390,6 @@ def _emit_summary_json(
         "RECONCILE_SUMMARY json=%s",
         json.dumps(summary),
     )
-
-
-# ---------------------------------------------------------------------------
-# Minimal dataclass for future expansion (placeholder for Phase 2)
-# ---------------------------------------------------------------------------
 
 
 @dataclass(slots=True)

--- a/src/github2gerrit/pr_content_filter.py
+++ b/src/github2gerrit/pr_content_filter.py
@@ -136,15 +136,12 @@ class DependabotRule(FilterRule):
         log.info("Applying Dependabot filtering rules")
         filtered = body
 
-        # Step 1: Expand collapsed sections
         if config.expand_release_notes or config.expand_commits:
             filtered = self._expand_html_details(filtered)
 
-        # Step 2: Remove compatibility images
         if config.remove_compatibility_images:
             filtered = self._remove_compatibility_images(filtered)
 
-        # Step 3: Truncate at command instructions
         if config.truncate_at_commands:
             filtered = self._truncate_at_dependabot_commands(filtered)
 
@@ -229,7 +226,6 @@ class PRContentFilter:
         if not self.config.enabled or not body:
             return False
 
-        # Check author-specific rules first
         if author in self.config.author_rules:
             rule_name = self.config.author_rules[author]
             return any(
@@ -270,7 +266,6 @@ class PRContentFilter:
         """Apply global pre-processing rules."""
         processed = body
 
-        # Remove title duplication first, before other processing
         if self.config.deduplicate_title_in_body:
             processed = self._remove_title_duplication(title, processed)
 
@@ -280,17 +275,13 @@ class PRContentFilter:
         """Apply global post-processing rules."""
         processed = body
 
-        # Remove emoji codes
         if self.config.remove_emoji_codes:
             processed = self._remove_emoji_codes(processed)
 
-        # Clean HTML and markdown
         processed = self._clean_html_and_markdown(processed)
 
-        # Clean up whitespace
         processed = self._clean_whitespace(processed)
 
-        # Remove trailing ellipses
         processed = self._remove_trailing_ellipses(processed)
 
         return processed
@@ -301,12 +292,10 @@ class PRContentFilter:
         # e.g., "<h3>:sparkles: New features</h3>" -> "<h3>New features</h3>"
         content = re.sub(r"(<[^>]*>)\s*:[a-z_]+:\s*", r"\1", content)
 
-        # Remove emoji codes while preserving line structure
         lines = content.splitlines()
         cleaned_lines = []
 
         for line in lines:
-            # Remove emoji codes from each line
             cleaned_line = _EMOJI_PATTERN.sub("", line)
             # Clean up multiple spaces that might result from emoji removal
             cleaned_line = re.sub(r"  +", " ", cleaned_line)
@@ -404,7 +393,6 @@ class PRContentFilter:
         if first_content_line_idx is None:
             return body  # No content found
 
-        # Clean both title and first content line for comparison
         title_clean = self._clean_for_comparison(title)
         first_line_clean = self._clean_for_comparison(first_content_line)
 
@@ -429,9 +417,7 @@ class PRContentFilter:
 
     def _clean_for_comparison(self, text: str) -> str:
         """Clean text for comparison by removing markdown and punctuation."""
-        # Remove markdown links
         cleaned = _MARKDOWN_LINK_PATTERN.sub(r"\1", text)
-        # Remove trailing periods and normalize spacing
         cleaned = cleaned.strip().rstrip(".")
         return cleaned
 
@@ -452,12 +438,10 @@ class PRContentFilter:
         cleaned_lines = []
 
         for line in lines:
-            # Remove lines that are just "..." or whitespace + "..."
             stripped = line.strip()
             if stripped == "..." or stripped == "…":
                 continue
 
-            # Remove trailing ellipses from lines
             cleaned_line = re.sub(r"\s*\.{3,}\s*$", "", line)
             cleaned_line = re.sub(r"\s*…\s*$", "", cleaned_line)
             cleaned_lines.append(cleaned_line)
@@ -478,7 +462,6 @@ def create_default_filter() -> PRContentFilter:
     """Create a filter with default configuration."""
     config = FilterConfig()
 
-    # Set up default author mappings
     config.author_rules.update(
         {
             "dependabot[bot]": "dependabot",

--- a/src/github2gerrit/reconcile_matcher.py
+++ b/src/github2gerrit/reconcile_matcher.py
@@ -243,7 +243,6 @@ class ReconciliationMatcher:
         """Pass A: Match commits that already have Change-ID trailers."""
         remaining = []
 
-        # Build lookup map for Gerrit changes
         gerrit_by_id = {change.change_id: change for change in gerrit_changes}
 
         for commit in commits:
@@ -291,7 +290,6 @@ class ReconciliationMatcher:
         """Pass B: Match by exact normalized subject."""
         remaining = []
 
-        # Build lookup map by normalized subject
         gerrit_by_subject: dict[str, list[GerritChange]] = {}
         for change in gerrit_changes:
             if change.change_id in used_changes:
@@ -351,7 +349,6 @@ class ReconciliationMatcher:
         """Pass C: Match by file signature (same set of files)."""
         remaining = []
 
-        # Build lookup map by file signature
         gerrit_by_files: dict[str, list[GerritChange]] = {}
         for change in gerrit_changes:
             if change.change_id in used_changes:
@@ -392,7 +389,6 @@ class ReconciliationMatcher:
                 strategy_counts.get(MatchStrategy.FILE_SIGNATURE, 0) + 1
             )
 
-            # Remove from candidates
             candidates.remove(gerrit_change)
             if not candidates:
                 del gerrit_by_files[file_sig]
@@ -417,7 +413,6 @@ class ReconciliationMatcher:
         """Pass D: Match by subject token similarity (Jaccard)."""
         remaining = []
 
-        # Get available Gerrit changes
         available_changes = [
             change
             for change in gerrit_changes
@@ -461,7 +456,6 @@ class ReconciliationMatcher:
                     strategy_counts.get(MatchStrategy.SUBJECT_SIMILARITY, 0) + 1
                 )
 
-                # Remove from available changes
                 available_changes.remove(gerrit_change)
 
                 log.debug(

--- a/src/github2gerrit/rich_display.py
+++ b/src/github2gerrit/rich_display.py
@@ -6,7 +6,12 @@ Rich display utilities for enhanced CLI output.
 
 Provides formatted output for PR information, progress tracking, and
 operation status using Rich formatting library.
+
+This module is the console-display layer for the CLI: bare print()
+calls are the deliberate output path when Rich is not installed.
 """
+
+# aislop-ignore-file python-print-debug
 
 from __future__ import annotations
 
@@ -172,7 +177,6 @@ def display_pr_info(
     # Use Rich display context to manage logging interference
     display_context_id = f"pr_info_display_{id(pr_info)}"
 
-    # Build display title with context
     if context:
         display_title = f"{context} Pull Request Details"
     elif title:
@@ -249,7 +253,6 @@ class ProgressTracker:
 
     def start(self) -> None:
         """Start the progress display with in-place updates."""
-        # Start Rich display context to manage logging interference
         if self.rich_available:
             context_id = f"progress_tracker_{id(self)}"
             self._rich_context = RichDisplayContext(context_id)
@@ -265,7 +268,6 @@ class ProgressTracker:
 
     def stop(self) -> None:
         """Stop the progress display."""
-        # Clean up Rich display context
         if self._rich_context:
             import contextlib
 

--- a/src/github2gerrit/rich_logging.py
+++ b/src/github2gerrit/rich_logging.py
@@ -14,7 +14,12 @@ Key features:
 - Background-only logging for DEBUG/INFO when Rich is active
 - Seamless fallback to normal logging when Rich is not available
 - Thread-safe operation for concurrent logging
+
+This module is the console-output layer for logging: bare print()
+calls are the deliberate output path when Rich is not installed.
 """
+
+# aislop-ignore-file python-print-debug
 
 from __future__ import annotations
 
@@ -61,7 +66,6 @@ class RichAwareLogger:
         self._context_lock = threading.Lock()
 
         if RICH_AVAILABLE:
-            # Create a dedicated Rich console for logging
             self._rich_console = Console(stderr=True, markup=False)
 
     @classmethod
@@ -136,7 +140,6 @@ class RichAwareHandler(logging.Handler):
         super().__init__()
         self._rich_console = rich_console
 
-        # Set up formatting
         formatter = logging.Formatter("%(levelname)s: %(message)s")
         self.setFormatter(formatter)
 
@@ -159,7 +162,6 @@ class RichAwareHandler(logging.Handler):
                 style = "white"
                 prefix = "i"
 
-            # Print through Rich console
             self._rich_console.print(f"{prefix} {msg}", style=style)
 
         except Exception:
@@ -180,7 +182,6 @@ class VerboseAwareHandler(logging.Handler):
         super().__init__()
         self._rich_console = rich_console
 
-        # Set up formatting for debug messages
         formatter = logging.Formatter("%(levelname)s: %(name)s: %(message)s")
         self.setFormatter(formatter)
 
@@ -209,7 +210,6 @@ class VerboseAwareHandler(logging.Handler):
                         style = "dim white"
                         prefix = "🔍"
 
-                    # Print through Rich console
                     self._rich_console.print(f"{prefix} {msg}", style=style)
                 except Exception:
                     # Fallback to handleError if Rich printing fails

--- a/src/github2gerrit/similarity.py
+++ b/src/github2gerrit/similarity.py
@@ -112,14 +112,12 @@ def normalize_subject(subject: str) -> str:
         Normalized subject string.
     """
     s = (subject or "").strip()
-    # Remove conventional commit prefixes
     s = re.sub(
         r"^(feat|fix|docs|style|refactor|test|chore|ci|build|perf)(\(.+?\))?:\s*",
         "",
         s,
         flags=re.IGNORECASE,
     )
-    # Remove lightweight markdown punctuation
     s = re.sub(r"[*_`]", "", s)
     # Normalize versions and commit hashes
     s = re.sub(r"\bv\d+(\.\d+)*(-[\w.]+)?\b", "vx.y.z", s)
@@ -151,7 +149,6 @@ def normalize_body(body: str | None) -> str:
     if not body:
         return ""
     b = body.lower()
-    # Remove URLs
     b = re.sub(r"https?://\S+", "", b)
     # Normalize versions and commit hashes and dates
     b = re.sub(
@@ -374,7 +371,6 @@ def score_files(
 
     def _nf(p: str) -> str:
         q = (p or "").strip().lower()
-        # Remove embedded version-like fragments
         q = re.sub(r"v?\d+\.\d+\.\d+(?:\.\d+)?(?:-[\w.-]+)?", "", q)
         q = re.sub(r"\s+", " ", q).strip()
         return q

--- a/src/github2gerrit/ssh_agent_setup.py
+++ b/src/github2gerrit/ssh_agent_setup.py
@@ -95,10 +95,8 @@ class SSHAgentManager:
             # Locate ssh-agent executable
             ssh_agent_path = _ensure_tool_available("ssh-agent")
 
-            # Start ssh-agent and capture its output
             result = run_cmd([ssh_agent_path, "-s"], timeout=10)
 
-            # Parse the ssh-agent output to get environment variables
             for line in result.stdout.strip().split("\n"):
                 if line.startswith("SSH_AUTH_SOCK="):
                     # Format: SSH_AUTH_SOCK=/path/to/socket; export
@@ -503,7 +501,6 @@ def setup_ssh_agent_auth(
         )
         if manager.use_existing_agent():
             log.debug("Using existing SSH agent successfully")
-            # Setup known hosts for existing agent
             manager.setup_known_hosts(known_hosts_content)
 
             # Verify existing agent has keys using "ssh-add -l"
@@ -536,14 +533,12 @@ def setup_ssh_agent_auth(
             )
             _raise_no_agent_error()
 
-        # Start new SSH agent and add the private key
         log.debug("Starting new SSH agent with provided private key")
         manager.start_agent()
 
         # Add the private key
         manager.add_key(private_key_content)
 
-        # Setup known hosts
         manager.setup_known_hosts(known_hosts_content)
 
         # Verify key was added successfully using "ssh-add -l"
@@ -558,7 +553,6 @@ def setup_ssh_agent_auth(
         log.debug("Loaded keys: %s", keys_list)
 
     except Exception:
-        # Clean up on failure
         manager.cleanup()
         raise
     else:

--- a/src/github2gerrit/ssh_common.py
+++ b/src/github2gerrit/ssh_common.py
@@ -129,7 +129,6 @@ def build_git_ssh_command(
 
     ssh_cmd = f"ssh {' '.join(ssh_options)}"
 
-    # Log masked version for security
     if key_path:
         masked_cmd = ssh_cmd.replace(str(key_path), "[KEY_PATH]")
         log.debug("Generated SSH command: %s", masked_cmd)

--- a/src/github2gerrit/ssh_config_parser.py
+++ b/src/github2gerrit/ssh_config_parser.py
@@ -156,7 +156,6 @@ class SSHConfig:
             keyword = parts[0].lower()
 
             if keyword == "host":
-                # Start new host entry
                 if current_entry:
                     entries.append(current_entry)
 
@@ -301,7 +300,6 @@ def get_ssh_user_for_gerrit(
     default_config_path = Path.home() / ".ssh" / "config"
     cache_key = str(default_config_path)
 
-    # Get or create cached SSH config instance
     if cache_key not in _ssh_config_cache:
         _ssh_config_cache[cache_key] = SSHConfig()
 
@@ -417,7 +415,6 @@ def get_git_user_email() -> str | None:
             log.debug("Git executable not found in PATH")
             return None
 
-        # Validate git executable path for security
         if not _validate_git_executable(git_path):
             log.debug("Git executable validation failed: %s", git_path)
             return None

--- a/src/github2gerrit/ssh_discovery.py
+++ b/src/github2gerrit/ssh_discovery.py
@@ -165,7 +165,6 @@ def fetch_ssh_host_keys(
                 _MSG_NO_KEYS_FOUND.format(hostname=hostname, port=port)
             )
 
-        # Validate that we got proper known_hosts format
         lines = result.stdout.strip().split("\n")
         valid_lines = []
 
@@ -260,8 +259,8 @@ def extract_gerrit_info_from_gitreview(content: str) -> tuple[str, int] | None:
         elif key == "port":
             try:
                 port = int(value)
-            except ValueError:
-                log.warning("Invalid port in .gitreview: %s", value)
+            except ValueError as exc:
+                log.warning("Invalid port in .gitreview: %s (%s)", value, exc)
 
     return (hostname, port) if hostname else None
 
@@ -289,7 +288,6 @@ def discover_and_save_host_keys(
     # Discover the host keys
     host_keys = fetch_ssh_host_keys(hostname, port)
 
-    # Save to configuration file
     save_host_keys_to_config(host_keys, organization, config_path)
 
     return host_keys
@@ -343,7 +341,6 @@ def save_host_keys_to_config(
         if config_file.exists():
             existing_content = config_file.read_text(encoding="utf-8")
 
-        # Parse existing content to find the organization section
         lines = existing_content.split("\n")
         new_lines = []
         in_org_section = False
@@ -353,7 +350,6 @@ def save_host_keys_to_config(
         for line in lines:
             stripped = line.strip()
 
-            # Check for section headers
             if stripped.startswith("[") and stripped.endswith("]"):
                 section_name = stripped[1:-1].strip().lower()
                 in_org_section = section_name == organization.lower()
@@ -402,7 +398,6 @@ def save_host_keys_to_config(
                 section_end, f'GERRIT_KNOWN_HOSTS = "{escaped_keys}"'
             )
 
-        # Write the updated configuration
         config_file.write_text("\n".join(new_lines), encoding="utf-8")
 
         log.debug(

--- a/src/github2gerrit/trailers.py
+++ b/src/github2gerrit/trailers.py
@@ -13,7 +13,6 @@ import re
 
 log = logging.getLogger(__name__)
 
-
 # Trailer key constants
 GITHUB_PR_TRAILER = "GitHub-PR"
 GITHUB_HASH_TRAILER = "GitHub-Hash"
@@ -56,7 +55,6 @@ def parse_trailers(commit_message: str) -> dict[str, list[str]]:
             trailer_start = i + 1
             break
 
-    # Parse trailer lines
     for raw_line in lines[trailer_start:]:
         line = raw_line.strip()
         if ":" in line:
@@ -182,13 +180,10 @@ def normalize_subject_for_matching(subject: str) -> str:
     if not subject:
         return ""
 
-    # Remove common prefixes and suffixes
     normalized = subject.strip()
 
-    # Remove version numbers and tags in brackets/parentheses
     normalized = re.sub(r"\s*[\[\(][vV]?\d+[\.\d]*[\]\)]\s*", " ", normalized)
 
-    # Remove "WIP:", "DRAFT:", etc. prefixes
     normalized = re.sub(
         r"^\s*(WIP|DRAFT|TODO|FIXME|HACK):\s*",
         "",
@@ -196,7 +191,6 @@ def normalize_subject_for_matching(subject: str) -> str:
         flags=re.IGNORECASE,
     )
 
-    # Remove trailing punctuation and whitespace
     normalized = re.sub(r"[.!]+\s*$", "", normalized)
 
     # Normalize whitespace
@@ -235,7 +229,6 @@ def compute_file_signature(file_paths: list[str]) -> str:
     # Sort for deterministic ordering
     normalized_paths.sort()
 
-    # Create hash of the sorted, normalized path list
     content = "\n".join(normalized_paths)
     hash_obj = hashlib.sha256(content.encode("utf-8"))
     return hash_obj.hexdigest()[:12]  # 12 hex chars = 48 bits


### PR DESCRIPTION
## Summary

The organisation now runs the `aislop` quality gate on every PR via the mandated ruleset workflow (`lfreleng-actions/.github` → "Audit changes", advisory mode today with enforcement planned via `AISLOP_ENFORCE`). Because the gate scans whole changed files, every PR touching these modules re-surfaces the same pre-existing findings — as seen on #324. This dedicated cleanup clears that debt in one reviewable change.

## Changes

### Auto-fixed (aislop 0.13.1, the version pinned by `aislop-scan-action`)

- Deleted **265 trivial restating comments** and **40 narrative/decorative separator blocks** across 26 source files — pure comment deletions (verified: only removed `#` comment lines; no `noqa`/`type: ignore`/SPDX/pragma lines touched)
- One removed comment documenting non-obvious design intent (`G2G_NO_GERRIT` reusing the `DRY_RUN` network-suppression paths) was **restored**

### Manual fixes (all remaining non-complexity findings in touched files)

- **`cli.py`**: dropped the unreachable `importlib_metadata` backport fallback in `get_version()` — stdlib for every supported Python (≥3.11) and not a declared dependency (`hallucinated-import`, error severity). Removed the matching mypy override from `pyproject.toml`
- **`core.py`**: Issue-ID console notice now routes through `safe_console_print()` instead of a bare `print()`, matching the rest of the CLI output path
- **`gerrit_query.py`**: split the chained `.get(..., {})` lookups in `GerritChange.from_dict()` into explicit steps that also tolerate null `revisions`/`commit` payloads
- **`netrc.py`**: replaced the escape-sequence `elif` ladder with a mapping table
- **`cli.py`, `config.py`, `ssh_discovery.py`**: caught exceptions now included in warning/debug logs so failure causes stay diagnosable
- **`rich_display.py`, `rich_logging.py`**: module docstrings now state that bare `print()` calls are the deliberate no-Rich output path; `python-print-debug` suppressed file-wide via `aislop-ignore-file`
- Inline `aislop-ignore-next-line` suppressions with rationale comments where the code is intentional: cosmetic version banner (`swallowed-exception`), `log.exception` diagnostic helpers (`silent-recovery`), and status-logging ladders whose branches differ in log level (`python-repetitive-dispatch`)

## Results

| Metric | Before | After |
| --------------------------------------------- | ------ | ----- |
| aislop score | 17/100 | 30/100 |
| Errors | 8 | 0 |
| Non-complexity findings in files this PR touches | 330+ | 0 |

Remaining findings are `complexity/*` (file/function size — needs refactoring, `core.py` is ~6,600 lines) plus hardcoded-URL/broad-except cases in files this PR does not touch; deliberately out of scope.

## Testing

- Full test suite passes (`uv run pytest`, coverage 69.7% vs 65% gate)
- All 25 prek hooks pass (`prek run --all-files`)
- `aislop scan`: 0 errors, 0 fixable, 0 non-complexity findings in touched files

## Sequencing

Review/merge this first; #324 will then be rebased on top.