### PR TITLE
CI: Set coverage data_file outside project tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,12 @@ disallow_untyped_calls = false
 
 [tool.coverage.run]
 branch = true
+# Keep transient coverage data out of the working tree so tests that
+# inspect on-disk repository content never see .coverage* files.
+# During pytest runs tests/conftest.py sets COVERAGE_FILE (env), which
+# takes precedence; this value covers direct coverage invocations and
+# satisfies python-test-action's data_file configuration check.
+data_file = "${TMPDIR-/tmp}/.coverage.github2gerrit"
 source = ["github2gerrit"]
 omit = [
   "tests/*",


### PR DESCRIPTION
## Summary

The `python-test-action` step in the release workflow emits this warning:

> ⚠️ Coverage configuration warning
> Discovered coverage config does not set `data_file`.
> Tests sensitive to filesystem content may break.

The action adopts `pyproject.toml` as the coverage config (it contains a `[tool.coverage.run]` section) and greps it for an explicit `data_file` setting, which was absent. coverage.py's default writes `.coverage` into the working directory, where it can collide with on-disk fixtures used by tests.

## Change

Set `data_file` under `[tool.coverage.run]` to a path outside the project tree, using coverage.py's environment variable substitution:

```toml
data_file = "${TMPDIR-/tmp}/.coverage.github2gerrit"
```

- Resolves under `$TMPDIR` on macOS/dev machines; falls back to `/tmp` on Linux CI runners where `TMPDIR` is unset (verified via `coverage debug config` in both cases)
- Behaviour during pytest runs is unchanged: `tests/conftest.py` already exports `COVERAGE_FILE` (env), which takes precedence over the config value
- The CI XML report is written directly by pytest-cov (`--cov-report=xml:...`) and is independent of the data-file location

## Validation

- `uv run pytest` — 1350 passed, coverage 69.8% (gate 65%)
- `prek run --all-files` — all hooks pass
- `coverage debug config` confirms resolution with and without `TMPDIR` set