### PR TITLE
Fix: Reconcile closed changes and bundle action/workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,12 @@
 
 # Path-specific configurations.
 paths:
+  .github/workflows/github2gerrit.yaml:
+    ignore:
+      # actionlint's github context schema does not yet include the
+      # documented job_workflow_ref/job_workflow_sha properties that
+      # identify the reusable workflow's own repository and commit
+      - 'property "job_workflow_(ref|sha)" is not defined in object type .+'
   .github/workflows/testing.yaml:
     ignore:
       # Ignore deliberate test failure

--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -296,8 +296,13 @@ jobs:
         run: |
           # Extract owner/repo from a job_workflow_ref such as:
           # owner/repo/.github/workflows/github2gerrit.yaml@refs/tags/v1.4.1
-          echo "repository=${JOB_WORKFLOW_REF%%/.github/*}" \
-            >> "$GITHUB_OUTPUT"
+          repository="${JOB_WORKFLOW_REF%%/.github/*}"
+          if [[ ! "$repository" =~ ^[^/@]+/[^/@]+$ ]]; then
+            echo "Error: cannot derive owner/repo from" \
+              "job_workflow_ref: ${JOB_WORKFLOW_REF}" >&2
+            exit 1
+          fi
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
 
       - name: Checkout github2gerrit action at workflow SHA
         # yamllint disable-line rule:line-length

--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -6,6 +6,13 @@ name: "GitHub2Gerrit [R]"
 
 # Reusable workflow wrapping the github2gerrit composite action.
 #
+# The composite action is not pinned to a separate version: this
+# workflow checks out the action from its own repository at the exact
+# commit the caller pinned this workflow to (github.job_workflow_sha)
+# and runs it as a local action. Workflow and action therefore always
+# ship as one unit with matching input interfaces, and the Python tool
+# itself installs as the latest release from PyPI at runtime (uvx).
+#
 # Supported caller trigger events:
 #
 #   - pull_request_target (opened/reopened/edited/synchronize/closed):
@@ -267,10 +274,43 @@ jobs:
       gerrit_commit_sha: ${{ steps.g2g.outputs.gerrit_commit_sha }}
       # yamllint enable rule:line-length
     steps:
+      # Check out the target repository first; the composite action's
+      # internal checkout is skipped (SKIP_CHECKOUT) so it cannot wipe
+      # the bundled action checkout performed below
+      - name: Checkout target repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: ${{ inputs.FETCH_DEPTH }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      # Resolve the repository that provides this reusable workflow so
+      # the bundled action ships from the exact same commit; the
+      # workflow and action interfaces then never drift apart
+      - name: Resolve workflow source repository
+        id: workflow-source
+        shell: bash
+        env:
+          JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+        run: |
+          # Extract owner/repo from a job_workflow_ref such as:
+          # owner/repo/.github/workflows/github2gerrit.yaml@refs/tags/v1.4.1
+          echo "repository=${JOB_WORKFLOW_REF%%/.github/*}" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Checkout github2gerrit action at workflow SHA
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.workflow-source.outputs.repository }}
+          ref: ${{ github.job_workflow_sha }}
+          path: .g2g-action
+          persist-credentials: false
+
       - name: Run github2gerrit composite action
         id: g2g
-        # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/github2gerrit-action@f44c168376b369be0f306b6bdc07c80f67cceb05 # v1.3.3
+        uses: ./.g2g-action
         env:
           # Gerrit event dispatch context: when GERRIT_CHANGE_URL and
           # GERRIT_EVENT_TYPE carry values, the tool closes the source
@@ -281,6 +321,7 @@ jobs:
           GERRIT_EVENT_TYPE: ${{ inputs.GERRIT_EVENT_TYPE }}
           GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
         with:
+          SKIP_CHECKOUT: true
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
           SUBMIT_SINGLE_COMMITS: ${{ inputs.SUBMIT_SINGLE_COMMITS }}
           USE_PR_AS_COMMIT: ${{ inputs.USE_PR_AS_COMMIT }}

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,15 @@ inputs:
     description: "Fetch depth for checkout"
     required: false
     default: "10"
+  SKIP_CHECKOUT:
+    description: >-
+      Skip the internal repository checkout. Set when the caller has
+      already checked out the target repository at the desired ref
+      (e.g. the bundled reusable workflow, which also checks out this
+      action into the workspace and must not have it deleted by a
+      nested checkout)
+    required: false
+    default: "false"
   PR_NUMBER:
     description: "Pull request number to process, use 0 to process all open"
     required: false
@@ -205,7 +214,8 @@ runs:
         fi
 
     - name: "Checkout repository"
-      if: steps.disabled-check.outputs.disabled != 'true'
+      # yamllint disable-line rule:line-length
+      if: steps.disabled-check.outputs.disabled != 'true' && inputs.SKIP_CHECKOUT != 'true'
       # yamllint disable-line rule:line-length
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -41,6 +41,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from typing import Literal
 from urllib.request import Request
 from urllib.request import urlopen
 
@@ -1970,12 +1971,12 @@ class Orchestrator:
                 shas.append(info["current_revision"])
 
         # Overall status: MERGED wins for messaging purposes
-        overall_status = (
+        overall_status: Literal["MERGED", "ABANDONED"] = (
             "MERGED"
             if any(info["status"] == "MERGED" for _, info in states)
             else "ABANDONED"
         )
-        change_ref = urls[0] if urls else ", ".join(change_ids)
+        change_ref = ", ".join(urls) if urls else ", ".join(change_ids)
         log.info(
             "Gerrit change(s) for PR #%s already %s: %s",
             gh.pr_number,
@@ -1986,16 +1987,33 @@ class Orchestrator:
         close_merged_prs = env_bool("CLOSE_MERGED_PRS", True)
         pr_url = f"{gh.server_url}/{gh.repository}/pull/{gh.pr_number}"
         try:
-            from .gerrit_pr_closer import close_pr_with_status
+            if close_merged_prs or overall_status == "ABANDONED":
+                # Closes the PR, or posts a comment-only notification
+                # for ABANDONED changes when CLOSE_MERGED_PRS is false
+                from .gerrit_pr_closer import close_pr_with_status
 
-            close_pr_with_status(
-                pr_url=pr_url,
-                gerrit_change_url=urls[0] if urls else None,
-                gerrit_status=overall_status,  # type: ignore[arg-type]
-                dry_run=False,
-                progress_tracker=None,
-                close_merged_prs=close_merged_prs,
-            )
+                close_pr_with_status(
+                    pr_url=pr_url,
+                    gerrit_change_url=change_ref if urls else None,
+                    gerrit_status=overall_status,
+                    dry_run=False,
+                    progress_tracker=None,
+                    close_merged_prs=close_merged_prs,
+                )
+            else:
+                # close_pr_with_status posts no comment for MERGED
+                # changes when CLOSE_MERGED_PRS is false; comment here
+                # so the early pipeline stop is explained on the PR
+                client = build_client()
+                repo_obj = get_repo_from_env(client)
+                pr_obj = get_pull(repo_obj, int(gh.pr_number))
+                comment = (
+                    "The Gerrit change for this pull request has "
+                    f"merged: {change_ref}\n\n"
+                    "No further patchsets can be submitted; this pull "
+                    "request is now redundant and can be closed."
+                )
+                create_pr_comment(pr_obj, comment)
         except Exception as exc:
             log.warning(
                 "Failed to reconcile GitHub PR #%s for %s Gerrit change: %s",

--- a/src/github2gerrit/core.py
+++ b/src/github2gerrit/core.py
@@ -1860,6 +1860,156 @@ class Orchestrator:
             )
             raise OrchestratorError(_MSG_DNS_RESOLUTION_FAILED % host) from exc
 
+    def _lookup_change_state(
+        self,
+        gerrit: GerritInfo,
+        change_id: str,
+    ) -> dict[str, str] | None:
+        """Query Gerrit for the current state of a change by Change-Id.
+
+        Scopes the query to the Gerrit project to avoid ambiguous
+        Change-Id lookups across projects.
+
+        Returns:
+            Dict with 'status', 'number' and 'current_revision' keys,
+            or None when the change cannot be found or queried.
+        """
+        try:
+            from .gerrit_rest import build_client_for_host
+
+            client = build_client_for_host(
+                gerrit.host, timeout=8.0, max_attempts=3
+            )
+            query = f"change:{change_id} project:{gerrit.project}"
+            encoded_q = urllib.parse.quote(query, safe="")
+            data = client.get(f"/changes/?q={encoded_q}&n=1&o=CURRENT_REVISION")
+            if isinstance(data, list) and data:
+                change = data[0]
+                if isinstance(change, dict):
+                    return {
+                        "status": str(change.get("status", "")),
+                        "number": str(change.get("_number", "")),
+                        "current_revision": str(
+                            change.get("current_revision", "")
+                        ),
+                    }
+        except Exception as exc:
+            log.debug("Failed to query state for change %s: %s", change_id, exc)
+        return None
+
+    def _reconcile_final_state_changes(
+        self,
+        *,
+        gh: GitHubContext,
+        gerrit: GerritInfo,
+        change_ids: list[str],
+    ) -> SubmissionResult | None:
+        """Reconcile GitHub PR state against final-state Gerrit changes.
+
+        When reconciliation resolves existing Change-Id(s) for a PR,
+        verify their status in Gerrit before pushing. If every resolved
+        change is already MERGED or ABANDONED, pushing a new patchset
+        would be rejected ("change ... closed"). Instead, act on the
+        GitHub PR:
+
+        - MERGED: close the PR with an explanatory comment (honoring
+          CLOSE_MERGED_PRS; when false, comment only).
+        - ABANDONED: close or comment per CLOSE_MERGED_PRS.
+
+        Returns:
+            SubmissionResult describing the existing change(s) when the
+            pipeline should stop (all changes final), or None to
+            proceed with the normal push flow.
+        """
+        if not change_ids or not gh.pr_number:
+            return None
+
+        states: list[tuple[str, dict[str, str]]] = []
+        for cid in change_ids:
+            info = self._lookup_change_state(gerrit, cid)
+            if info is None:
+                # Fail open: unknown state must not block submission
+                return None
+            states.append((cid, info))
+
+        final_states = {"MERGED", "ABANDONED"}
+        if not all(info["status"] in final_states for _, info in states):
+            open_ids = [
+                cid
+                for cid, info in states
+                if info["status"] not in final_states
+            ]
+            closed_ids = [
+                cid for cid, info in states if info["status"] in final_states
+            ]
+            if closed_ids:
+                log.warning(
+                    "Some reused Gerrit change(s) are already closed "
+                    "(%s); proceeding with open change(s): %s",
+                    ", ".join(closed_ids),
+                    ", ".join(open_ids),
+                )
+            return None
+
+        # All resolved changes are in a final state
+        url_builder = create_gerrit_url_builder(gerrit.host)
+        urls: list[str] = []
+        nums: list[str] = []
+        shas: list[str] = []
+        for _cid, info in states:
+            if info["number"]:
+                try:
+                    change_number = int(info["number"])
+                except ValueError:
+                    continue
+                urls.append(
+                    url_builder.change_url(gerrit.project, change_number)
+                )
+                nums.append(info["number"])
+            if info["current_revision"]:
+                shas.append(info["current_revision"])
+
+        # Overall status: MERGED wins for messaging purposes
+        overall_status = (
+            "MERGED"
+            if any(info["status"] == "MERGED" for _, info in states)
+            else "ABANDONED"
+        )
+        change_ref = urls[0] if urls else ", ".join(change_ids)
+        log.info(
+            "Gerrit change(s) for PR #%s already %s: %s",
+            gh.pr_number,
+            overall_status.lower(),
+            change_ref,
+        )
+
+        close_merged_prs = env_bool("CLOSE_MERGED_PRS", True)
+        pr_url = f"{gh.server_url}/{gh.repository}/pull/{gh.pr_number}"
+        try:
+            from .gerrit_pr_closer import close_pr_with_status
+
+            close_pr_with_status(
+                pr_url=pr_url,
+                gerrit_change_url=urls[0] if urls else None,
+                gerrit_status=overall_status,  # type: ignore[arg-type]
+                dry_run=False,
+                progress_tracker=None,
+                close_merged_prs=close_merged_prs,
+            )
+        except Exception as exc:
+            log.warning(
+                "Failed to reconcile GitHub PR #%s for %s Gerrit change: %s",
+                gh.pr_number,
+                overall_status.lower(),
+                exc,
+            )
+
+        return SubmissionResult(
+            change_urls=urls,
+            change_numbers=nums,
+            commit_shas=shas,
+        )
+
     def execute(
         self,
         inputs: Inputs,
@@ -2031,6 +2181,18 @@ class Orchestrator:
                 reuse_ids = self._perform_robust_reconciliation(
                     inputs, gh, gerrit, single_commit
                 )
+
+        # State reconciliation: when every Gerrit change resolved for
+        # this PR is already in a final state (merged/abandoned), the
+        # PR is redundant. Act on the GitHub PR instead of pushing a
+        # patchset that Gerrit will reject with "change ... closed".
+        early_result = self._reconcile_final_state_changes(
+            gh=gh,
+            gerrit=gerrit,
+            change_ids=reuse_ids,
+        )
+        if early_result is not None:
+            return early_result
 
         # Now prepare commits once with the correct reuse_ids
         if inputs.submit_single_commits:
@@ -4276,8 +4438,13 @@ class Orchestrator:
             # Analyze the specific failure reason from git review output
             error_details = self._analyze_gerrit_push_failure(exc)
 
-            # Always log the error details, even if not in verbose mode
-            log.exception("Gerrit push failed: %s", error_details)
+            # Log the analyzed error; reserve the full traceback for
+            # verbose/debug mode to keep console output actionable
+            if is_verbose_mode():
+                log.exception("Gerrit push failed: %s", error_details)
+            else:
+                # Deliberately omit the traceback outside verbose mode
+                log.error("Gerrit push failed: %s", error_details)  # noqa: TRY400
 
             # In debug mode, also show the raw command output
             if is_verbose_mode():
@@ -4827,6 +4994,11 @@ class Orchestrator:
             )
             if rejection_match:
                 reason = rejection_match.group(1).strip()
+                if re.search(r"change\s+\S+\s+closed", reason):
+                    return (
+                        "Gerrit change is closed (merged or abandoned) "
+                        f"and cannot accept new patchsets: {reason}"
+                    )
                 return f"Gerrit rejected the push: {reason}"
 
             # Fallback: look line by line
@@ -4835,6 +5007,12 @@ class Orchestrator:
                 if "! [remote rejected]" in line:
                     if "(" in line and ")" in line:
                         reason = line[line.find("(") + 1 : line.find(")")]
+                        if re.search(r"change\s+\S+\s+closed", reason):
+                            return (
+                                "Gerrit change is closed (merged or "
+                                "abandoned) and cannot accept new "
+                                f"patchsets: {reason}"
+                            )
                         return f"Gerrit rejected the push: {reason}"
                     return f"Gerrit rejected the push: {line.strip()}"
             return "Gerrit rejected the push for an unknown reason"

--- a/src/github2gerrit/error_codes.py
+++ b/src/github2gerrit/error_codes.py
@@ -473,6 +473,19 @@ def map_orchestrator_error_to_exit_code(
     if original_exception and is_network_error(original_exception):
         return ExitCode.NETWORK_ERROR
 
+    # Final-state Gerrit change patterns: pushing a patchset to a
+    # merged/abandoned change is a state problem, not a connection
+    # problem. Check before the connection patterns because these
+    # messages also contain "failed to push".
+    final_state_patterns = [
+        r"change is closed \(merged or abandoned\)",
+        r"cannot accept new patchsets",
+        r"change\s+\S+\s+closed",
+    ]
+
+    if any(re.search(pattern, error_lower) for pattern in final_state_patterns):
+        return ExitCode.GERRIT_CHANGE_ALREADY_FINAL
+
     # Gerrit connection error patterns
     gerrit_patterns = [
         r"failed to push",
@@ -542,6 +555,12 @@ def convert_orchestrator_error(
             "❌ Git repository access failed; check repository permissions"
         )
         details = f"Repository issue: {error_msg}"
+    elif exit_code == ExitCode.GERRIT_CHANGE_ALREADY_FINAL:
+        user_message = (
+            "❌ Gerrit change is already merged or abandoned; "
+            "no new patchsets can be pushed"
+        )
+        details = f"Gerrit change state issue: {error_msg}"
     else:
         user_message = "❌ Operation failed; check logs for details"
         details = error_msg

--- a/tests/test_final_state_reconciliation.py
+++ b/tests/test_final_state_reconciliation.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for final-state (merged/abandoned) Gerrit change reconciliation.
+
+Covers the regression where a re-run against a PR whose Gerrit change
+had already merged attempted to push a new patchset, which Gerrit
+rejected with "change ... closed" and the tool then misreported as an
+SSH/connection failure.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from github2gerrit.core import GerritInfo
+from github2gerrit.core import Orchestrator
+from github2gerrit.error_codes import ExitCode
+from github2gerrit.error_codes import map_orchestrator_error_to_exit_code
+from github2gerrit.gitutils import CommandError
+from github2gerrit.models import GitHubContext
+
+
+def _gh_context(pr_number: int | None = 33) -> GitHubContext:
+    return GitHubContext(
+        event_name="pull_request_target",
+        event_action="synchronize",
+        event_path=None,
+        repository="onap/policy-opa-pdp",
+        repository_owner="onap",
+        server_url="https://github.com",
+        run_id="123",
+        sha="abc123",
+        base_ref="master",
+        head_ref="dependabot/github_actions/foo",
+        pr_number=pr_number,
+    )
+
+
+def _gerrit_info() -> GerritInfo:
+    return GerritInfo(
+        host="gerrit.example.org",
+        port=29418,
+        project="policy/opa-pdp",
+    )
+
+
+class TestClosedChangePushAnalysis:
+    """Push failure analysis for closed-change rejections."""
+
+    def setup_method(self) -> None:
+        self.workspace = Path(tempfile.mkdtemp())
+        self.orchestrator = Orchestrator(workspace=self.workspace)
+
+    def test_closed_change_rejection_message(self) -> None:
+        output = (
+            "remote: error: change is closed\n"
+            " ! [remote rejected] HEAD -> refs/for/master "
+            "(change https://gerrit.example.org/r/c/policy/opa-pdp/+/146080 "
+            "closed)\n"
+            "error: failed to push some refs\n"
+        )
+        exc = CommandError(
+            "Command failed",
+            cmd=["git", "review"],
+            returncode=1,
+            stdout="",
+            stderr=output,
+        )
+        result = self.orchestrator._analyze_gerrit_push_failure(exc)
+
+        assert "closed (merged or abandoned)" in result
+        assert "146080" in result
+        # Must not be reported as a generic rejection
+        assert not result.startswith("Gerrit rejected the push:")
+
+
+class TestClosedChangeExitCode:
+    """Exit code mapping for closed-change push failures."""
+
+    def test_closed_change_maps_to_final_state_exit_code(self) -> None:
+        msg = (
+            "Failed to push changes to Gerrit with git-review: "
+            "Gerrit change is closed (merged or abandoned) and cannot "
+            "accept new patchsets: change "
+            "https://gerrit.example.org/r/c/policy/opa-pdp/+/146080 closed"
+        )
+        assert (
+            map_orchestrator_error_to_exit_code(msg)
+            == ExitCode.GERRIT_CHANGE_ALREADY_FINAL
+        )
+
+    def test_raw_closed_rejection_maps_to_final_state_exit_code(self) -> None:
+        msg = (
+            "Gerrit rejected the push: change "
+            "https://gerrit.example.org/r/c/x/+/1 closed"
+        )
+        assert (
+            map_orchestrator_error_to_exit_code(msg)
+            == ExitCode.GERRIT_CHANGE_ALREADY_FINAL
+        )
+
+    def test_ssh_failure_still_maps_to_connection_error(self) -> None:
+        msg = (
+            "Failed to push changes to Gerrit with git-review: "
+            "SSH public key authentication failed."
+        )
+        assert (
+            map_orchestrator_error_to_exit_code(msg)
+            == ExitCode.GERRIT_CONNECTION_ERROR
+        )
+
+
+class TestReconcileFinalStateChanges:
+    """Pre-push reconciliation of PRs whose Gerrit changes are final."""
+
+    def setup_method(self) -> None:
+        self.workspace = Path(tempfile.mkdtemp())
+        self.orchestrator = Orchestrator(workspace=self.workspace)
+        self.gh = _gh_context()
+        self.gerrit = _gerrit_info()
+
+    def _run(self, change_ids: list[str]) -> Any:
+        return self.orchestrator._reconcile_final_state_changes(
+            gh=self.gh,
+            gerrit=self.gerrit,
+            change_ids=change_ids,
+        )
+
+    def test_no_change_ids_proceeds(self) -> None:
+        assert self._run([]) is None
+
+    def test_open_change_proceeds(self) -> None:
+        with mock.patch.object(
+            self.orchestrator,
+            "_lookup_change_state",
+            return_value={
+                "status": "NEW",
+                "number": "146080",
+                "current_revision": "deadbeef",
+            },
+        ):
+            assert self._run(["I" + "a" * 40]) is None
+
+    def test_unknown_state_fails_open(self) -> None:
+        with mock.patch.object(
+            self.orchestrator,
+            "_lookup_change_state",
+            return_value=None,
+        ):
+            assert self._run(["I" + "a" * 40]) is None
+
+    def test_merged_change_closes_pr_and_stops(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLOSE_MERGED_PRS", "true")
+        with (
+            mock.patch.object(
+                self.orchestrator,
+                "_lookup_change_state",
+                return_value={
+                    "status": "MERGED",
+                    "number": "146080",
+                    "current_revision": "deadbeef",
+                },
+            ),
+            mock.patch(
+                "github2gerrit.gerrit_pr_closer.close_pr_with_status",
+                return_value=True,
+            ) as mock_close,
+        ):
+            result = self._run(["I" + "a" * 40])
+
+        assert result is not None
+        assert result.change_numbers == ["146080"]
+        assert result.commit_shas == ["deadbeef"]
+        assert len(result.change_urls) == 1
+        assert "146080" in result.change_urls[0]
+
+        mock_close.assert_called_once()
+        kwargs = mock_close.call_args.kwargs
+        assert kwargs["pr_url"] == (
+            "https://github.com/onap/policy-opa-pdp/pull/33"
+        )
+        assert kwargs["gerrit_status"] == "MERGED"
+        assert kwargs["close_merged_prs"] is True
+
+    def test_abandoned_change_stops_with_abandoned_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLOSE_MERGED_PRS", "true")
+        with (
+            mock.patch.object(
+                self.orchestrator,
+                "_lookup_change_state",
+                return_value={
+                    "status": "ABANDONED",
+                    "number": "146081",
+                    "current_revision": "",
+                },
+            ),
+            mock.patch(
+                "github2gerrit.gerrit_pr_closer.close_pr_with_status",
+                return_value=True,
+            ) as mock_close,
+        ):
+            result = self._run(["I" + "b" * 40])
+
+        assert result is not None
+        assert mock_close.call_args.kwargs["gerrit_status"] == "ABANDONED"
+
+    def test_mixed_states_proceeds_with_warning(self) -> None:
+        states = iter(
+            [
+                {
+                    "status": "MERGED",
+                    "number": "1",
+                    "current_revision": "aaa",
+                },
+                {
+                    "status": "NEW",
+                    "number": "2",
+                    "current_revision": "bbb",
+                },
+            ]
+        )
+        with mock.patch.object(
+            self.orchestrator,
+            "_lookup_change_state",
+            side_effect=lambda *_a, **_k: next(states),
+        ):
+            assert self._run(["I" + "a" * 40, "I" + "b" * 40]) is None
+
+    def test_close_failure_still_stops_pipeline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLOSE_MERGED_PRS", "true")
+        with (
+            mock.patch.object(
+                self.orchestrator,
+                "_lookup_change_state",
+                return_value={
+                    "status": "MERGED",
+                    "number": "146080",
+                    "current_revision": "deadbeef",
+                },
+            ),
+            mock.patch(
+                "github2gerrit.gerrit_pr_closer.close_pr_with_status",
+                side_effect=RuntimeError("GitHub API error"),
+            ),
+        ):
+            result = self._run(["I" + "a" * 40])
+
+        # Even when the PR closure fails, we must not attempt the
+        # doomed push to a closed change.
+        assert result is not None

--- a/tests/test_final_state_reconciliation.py
+++ b/tests/test_final_state_reconciliation.py
@@ -190,6 +190,77 @@ class TestReconcileFinalStateChanges:
         assert kwargs["gerrit_status"] == "MERGED"
         assert kwargs["close_merged_prs"] is True
 
+    def test_merged_change_comments_when_close_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLOSE_MERGED_PRS", "false")
+        with (
+            mock.patch.object(
+                self.orchestrator,
+                "_lookup_change_state",
+                return_value={
+                    "status": "MERGED",
+                    "number": "146080",
+                    "current_revision": "deadbeef",
+                },
+            ),
+            mock.patch(
+                "github2gerrit.gerrit_pr_closer.close_pr_with_status",
+            ) as mock_close,
+            mock.patch("github2gerrit.core.build_client"),
+            mock.patch("github2gerrit.core.get_repo_from_env"),
+            mock.patch("github2gerrit.core.get_pull"),
+            mock.patch("github2gerrit.core.create_pr_comment") as mock_comment,
+        ):
+            result = self._run(["I" + "a" * 40])
+
+        # Pipeline still stops, the PR stays open, and users get an
+        # explanatory comment instead of silence
+        assert result is not None
+        mock_close.assert_not_called()
+        mock_comment.assert_called_once()
+        comment_body = mock_comment.call_args.args[1]
+        assert "merged" in comment_body
+        assert "146080" in comment_body
+
+    def test_multiple_merged_changes_reference_all_urls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLOSE_MERGED_PRS", "true")
+        states = iter(
+            [
+                {
+                    "status": "MERGED",
+                    "number": "101",
+                    "current_revision": "aaa",
+                },
+                {
+                    "status": "MERGED",
+                    "number": "102",
+                    "current_revision": "bbb",
+                },
+            ]
+        )
+        with (
+            mock.patch.object(
+                self.orchestrator,
+                "_lookup_change_state",
+                side_effect=lambda *_a, **_k: next(states),
+            ),
+            mock.patch(
+                "github2gerrit.gerrit_pr_closer.close_pr_with_status",
+                return_value=True,
+            ) as mock_close,
+        ):
+            result = self._run(["I" + "a" * 40, "I" + "b" * 40])
+
+        assert result is not None
+        assert result.change_numbers == ["101", "102"]
+        # The PR close/comment must reference every reconciled change
+        change_url_arg = mock_close.call_args.kwargs["gerrit_change_url"]
+        assert "101" in change_url_arg
+        assert "102" in change_url_arg
+
     def test_abandoned_change_stops_with_abandoned_status(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Two related fixes arising from a production failure in `onap/policy-opa-pdp` ([failing run](https://github.com/onap/policy-opa-pdp/actions/runs/29324350012/job/87177556058)), where a workflow re-run against PR #33 pushed a patchset to Gerrit change 146080 which had already **merged**, producing `! [remote rejected] (change ... closed)` — misreported as an SSH/connection failure (exit 5) with a full traceback in the console logs.

### Commit 1: Handle closed Gerrit changes on PR re-runs

- **Pre-push state reconciliation**: after Change-Id reuse is resolved, query each change's status in Gerrit. When every resolved change is in a final state (MERGED/ABANDONED), close the GitHub PR with an explanatory comment (honouring `CLOSE_MERGED_PRS`) and return the existing change details instead of attempting a push Gerrit will reject. Unknown states fail open; mixed open/closed states proceed with a warning.
- **Correct error classification**: `change ... closed` push rejections now map to `GERRIT_CHANGE_ALREADY_FINAL` (exit 10) with an accurate message, instead of `GERRIT_CONNECTION_ERROR` (exit 5) / "check SSH keys and server configuration".
- **Cleaner console output**: the push-failure traceback only appears in verbose mode; normal runs log a single analyzed error line.
- 11 new regression tests in `tests/test_final_state_reconciliation.py`.

### Commit 2: Bundle action with reusable workflow at same SHA

The reusable workflow pinned the composite action at v1.3.3 while the repo tagged v1.4.0/v1.4.1 — callers of the v1.4.1 reusable workflow silently ran the v1.3.3 action with a drifted input interface, and no release process step existed to bump the pin.

- The workflow now checks out the action from its own repository at `github.job_workflow_sha` (the exact commit the caller pinned) and runs it as a local action — workflow and action ship as one atomic unit, interfaces can never drift, and no release-time pin bump is needed
- New `SKIP_CHECKOUT` action input prevents the action's internal checkout from wiping the bundled action checkout (the workflow performs the target-repo checkout itself)
- The Python tool continues to float on the latest PyPI release via `uvx` (unchanged behavior for external repos)
- actionlint config: ignore for the documented-but-unrecognized `job_workflow_ref`/`job_workflow_sha` context properties

## Validation

- Full pytest suite passes (0 failures), including 11 new regression tests
- `ruff check`/`format`, `mypy`, `basedpyright` clean
- `actionlint` (1.7.11 and CI-pinned 1.7.12.24), `yamllint`, `zizmor` clean
- All repo pre-commit hooks pass