### PR TITLE
Fix: Resolve workflow source from job context

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,10 +6,12 @@
 paths:
   .github/workflows/github2gerrit.yaml:
     ignore:
-      # actionlint's github context schema does not yet include the
-      # documented job_workflow_ref/job_workflow_sha properties that
-      # identify the reusable workflow's own repository and commit
+      # actionlint's context schemas do not yet include the documented
+      # properties that identify the reusable workflow's own repository
+      # and commit: job.workflow_repository/job.workflow_sha and the
+      # legacy github.job_workflow_ref/job_workflow_sha (GHES fallback)
       - 'property "job_workflow_(ref|sha)" is not defined in object type .+'
+      - 'property "workflow_(repository|sha)" is not defined in object type .+'
   .github/workflows/testing.yaml:
     ignore:
       # Ignore deliberate test failure

--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -8,8 +8,8 @@ name: "GitHub2Gerrit [R]"
 #
 # The composite action is not pinned to a separate version: this
 # workflow checks out the action from its own repository at the exact
-# commit the caller pinned this workflow to (github.job_workflow_sha)
-# and runs it as a local action. Workflow and action therefore always
+# commit the caller pinned this workflow to (job.workflow_sha) and
+# runs it as a local action. Workflow and action therefore always
 # ship as one unit with matching input interfaces, and the Python tool
 # itself installs as the latest release from PyPI at runtime (uvx).
 #
@@ -122,6 +122,16 @@ on:
         type: boolean
       VERBOSE:
         description: "Enable verbose output (sets log level to DEBUG)"
+        required: false
+        default: false
+        type: boolean
+      G2G_NO_GERRIT:
+        description: >-
+          Test mode: skip all Gerrit server interactions. When true,
+          takes precedence over the G2G_NO_GERRIT repository variable
+          (used by CI to exercise the workflow_call path without
+          Gerrit access); when false or omitted, the repository
+          variable applies
         required: false
         default: false
         type: boolean
@@ -287,29 +297,54 @@ jobs:
 
       # Resolve the repository that provides this reusable workflow so
       # the bundled action ships from the exact same commit; the
-      # workflow and action interfaces then never drift apart
+      # workflow and action interfaces then never drift apart.
+      # job.workflow_repository/job.workflow_sha identify the reusable
+      # workflow on github.com; the legacy github.job_workflow_ref and
+      # github.job_workflow_sha properties act as a fallback for GitHub
+      # Enterprise Server, where the job context properties are not
+      # available
       - name: Resolve workflow source repository
         id: workflow-source
         shell: bash
         env:
+          JOB_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          JOB_WORKFLOW_SHA: ${{ job.workflow_sha }}
           JOB_WORKFLOW_REF: ${{ github.job_workflow_ref }}
+          LEGACY_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
         run: |
-          # Extract owner/repo from a job_workflow_ref such as:
-          # owner/repo/.github/workflows/github2gerrit.yaml@refs/tags/v1.4.1
-          repository="${JOB_WORKFLOW_REF%%/.github/*}"
+          # Resolve the workflow source repository and commit
+          source="job context"
+          repository="$JOB_WORKFLOW_REPOSITORY"
+          workflow_sha="$JOB_WORKFLOW_SHA"
+          if [[ -z "$repository" ]]; then
+            # Fall back to extracting owner/repo from a ref such as:
+            # owner/repo/.github/workflows/github2gerrit.yaml@refs/tags/v1.4.2
+            source="legacy github context"
+            repository="${JOB_WORKFLOW_REF%%/.github/*}"
+            workflow_sha="$LEGACY_WORKFLOW_SHA"
+          fi
           if [[ ! "$repository" =~ ^[^/@]+/[^/@]+$ ]]; then
-            echo "Error: cannot derive owner/repo from" \
-              "job_workflow_ref: ${JOB_WORKFLOW_REF}" >&2
+            echo "Error: cannot derive owner/repo (source: ${source};" \
+              "job.workflow_repository: '${JOB_WORKFLOW_REPOSITORY}';" \
+              "github.job_workflow_ref: '${JOB_WORKFLOW_REF}')" >&2
             exit 1
           fi
+          if [[ -z "$workflow_sha" ]]; then
+            echo "Error: cannot derive workflow commit SHA (source:" \
+              "${source}; job.workflow_sha: '${JOB_WORKFLOW_SHA}';" \
+              "github.job_workflow_sha: '${LEGACY_WORKFLOW_SHA}')" >&2
+            exit 1
+          fi
+          echo "Workflow source: ${repository}@${workflow_sha} (${source})"
           echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "sha=$workflow_sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout github2gerrit action at workflow SHA
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.workflow-source.outputs.repository }}
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ steps.workflow-source.outputs.sha }}
           path: .g2g-action
           persist-credentials: false
 
@@ -360,5 +395,5 @@ jobs:
           REVIEWERS_EMAIL: ${{ inputs.REVIEWERS_EMAIL }}
           ISSUE_ID: ${{ inputs.ISSUE_ID }}
           ISSUE_ID_LOOKUP_JSON: ${{ inputs.ISSUE_ID_LOOKUP_JSON }}
-          G2G_NO_GERRIT: ${{ vars.G2G_NO_GERRIT }}
+          G2G_NO_GERRIT: ${{ inputs.G2G_NO_GERRIT || vars.G2G_NO_GERRIT }}
           G2G_DISABLED: ${{ vars.G2G_DISABLED }}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,6 +16,12 @@ on:
       - '!.github/**'
       - '!.*'
       - '!tox.ini'
+      # Re-include the workflows this suite guards: the reusable
+      # workflow smoke test must run when the workflow plumbing
+      # changes (the v1.4.2 regression shipped in a workflow-only
+      # change that never triggered this suite)
+      - '.github/workflows/github2gerrit.yaml'
+      - '.github/workflows/testing.yaml'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -24,6 +30,28 @@ concurrency:
 permissions: {}
 
 jobs:
+  ### Test the reusable workflow path used by production callers ###
+  # This exercises the workflow_call plumbing that the composite
+  # action tests below cannot reach: the bundled-action checkout and
+  # the workflow source repository resolution from the job context.
+  # Runs on every trigger event (pull_request, push and
+  # workflow_dispatch) so all supported caller invocation modes get
+  # coverage. G2G_NO_GERRIT keeps the run hermetic: no Gerrit server
+  # access takes place.
+  reusable-workflow-test:
+    name: 'Test Reusable Workflow'
+    permissions:
+      contents: read  # Checkout for the mirror job and bundled action
+      pull-requests: write  # Comment on and update mirrored PRs
+      issues: write  # Post status/back-reference comments on issues
+    uses: ./.github/workflows/github2gerrit.yaml
+    with:
+      G2G_NO_GERRIT: true
+      AUTOMATION_ONLY: false
+      GERRIT_KNOWN_HOSTS: 'dummy-host ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC...'
+    secrets:
+      GERRIT_SSH_PRIVKEY_G2G: 'dummy-key'
+
   ### Test the GitHub Action in this Repository (PR context only) ###
   tests:
     name: 'Test GitHub Action'


### PR DESCRIPTION
## Problem

Every v1.4.2 invocation of the reusable workflow fails at the
"Resolve workflow source repository" step, regardless of trigger
event (`push`, `pull_request_target` and `workflow_dispatch` all
affected). Example production failure:
https://github.com/onap/portal-ng-bff/actions/runs/29572384041

```
Error: cannot derive owner/repo from job_workflow_ref:
Error: Process completed with exit code 1.
```

## Root cause

GitHub moved the properties identifying a reusable workflow's own
repository and commit from the `github` context
(`job_workflow_ref`/`job_workflow_sha`) to the `job` context
(`workflow_repository`/`workflow_sha`). Nonexistent context
properties evaluate to empty strings, so the bundled-action checkout
introduced in v1.4.2 (b0efe76) receives an empty ref and aborts.

## Why CI did not catch it

No CI job exercises the `workflow_call` path. The existing jobs in
`testing.yaml` cover the composite action directly (`uses: ./`, PR
events only) and the Python CLI against the Gerrit `sandbox` project;
the failing step only exists in the reusable workflow, so it shipped
in v1.4.2 with zero test executions.

## Changes

- `github2gerrit.yaml`: resolve the workflow source repository and
  commit from `job.workflow_repository`/`job.workflow_sha`, keeping
  the legacy `github.job_workflow_*` properties as a fallback for
  GitHub Enterprise Server, where the `job` context identity
  properties are not available. Clearer error messages report both
  sources.
- `github2gerrit.yaml`: expose `G2G_NO_GERRIT` as a `workflow_call`
  input (`inputs.G2G_NO_GERRIT || vars.G2G_NO_GERRIT`) so CI can
  exercise the workflow hermetically. Omitting the input preserves
  existing behavior.
- `testing.yaml`: add a `reusable-workflow-test` job that calls
  `./.github/workflows/github2gerrit.yaml` with `G2G_NO_GERRIT: true`
  and dummy credentials on every trigger event, covering the
  bundled-action checkout plumbing that production callers use. This
  job would have caught the regression before release.
- `actionlint.yaml`: extend ignore patterns to cover the `job`
  context identity properties not yet in actionlint's schema.

## Validation

- yamllint and actionlint pass
- Full pre-commit suite passes (including pytest)

## Follow-up

Once merged, tag v1.4.3 so downstream thin callers (e.g. the ONAP
portal-ng repositories currently pinned to the broken v1.4.2 commit)
can bump to a working release.