### PR TITLE
Fix: Silence a false-positive S310 in gitreview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,11 @@ ignore = [
 "sitecustomize.py" = ["S110", "SIM103", "SIM105", "PLW2901"]
 "src/github2gerrit/duplicate_detection.py" = ["S310"]
 "src/github2gerrit/gerrit_rest.py" = ["S310", "TRY301"]
+# S310 audits urlopen for non-HTTP schemes such as file:. This module
+# builds the URL from a literal https://raw.githubusercontent.com/ prefix
+# and passes it through _validate_raw_url, which requires scheme https and
+# host raw.githubusercontent.com before the fetch runs.
+"src/github2gerrit/gitreview.py" = ["S310"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["github2gerrit"]


### PR DESCRIPTION
## Why

The `aislop` hook **fails on a pristine checkout of `main`**, with no changes
applied. That makes this repository uncommittable without bypassing hooks,
which is prohibited. It blocked an unrelated estate-wide change from landing
here, and it blocks anyone else too.

## Root cause

`.aislop/config.yml` sets `ci.failBelow: 100`, so a perfect score is required.
The scan returns **98 / 100**, held down by exactly one finding:

```
[WARN] Audit URL open for permitted schemes. Allowing use of `file:` or
       custom schemes is often unexpected.
  src/github2gerrit/gitreview.py:326:18   (ruff/S310)
```

## Why it is a false positive

In `fetch_gitreview_raw` the URL is built from a **literal** prefix, then
validated before use:

```python
url = (
    f"https://raw.githubusercontent.com/"
    f"{repo}/refs/heads/{safe_branch}/.gitreview"
)
if not _validate_raw_url(url):
    log.debug("Skipping invalid raw URL: %s", url)
    continue
```

and `_validate_raw_url` is unambiguous:

```python
parsed = urllib.parse.urlparse(url)
return (
    parsed.scheme == "https"
    and parsed.netloc == "raw.githubusercontent.com"
)
```

The scheme is hardcoded, independently validated, and anything failing that
check is skipped before the fetch. The `file:`/custom-scheme risk S310 exists
to catch cannot occur on this path.

## The fix

Records the exemption as a `per-file-ignores` entry, which is how this
repository **already** handles the identical rule in two other modules:

```toml
"src/github2gerrit/duplicate_detection.py" = ["S310"]
"src/github2gerrit/gerrit_rest.py" = ["S310", "TRY301"]
```

A comment records the justification alongside it. **One file changed, five
lines added; no source code is touched.**

### Why not an inline `# noqa: S310`

I tried that first, since it is narrower. It does not survive:

- The call sits at 74 characters, so appending ` # noqa: S310` breaks the
  79-character line limit.
- Wrapping the call to make room works until `ruff format` collapses it back
  and discards the directive.
- Once `per-file-ignores` is in place, any leftover `noqa` is then reported as
  an unused directive by `RUF100`.

The per-file entry avoids that fight and matches existing precedent.

## Validation

`pre-commit run --all-files` — **every hook passes**, including `ruff`,
`ruff format`, `mypy`, `basedpyright`, `aislop` and the full `pytest` suite.
`aislop` now reports a passing gate.

## Follow-up

With this merged, `github2gerrit-action` can take the cache-clearing thin
caller that the other 39 caching repositories have already received.
